### PR TITLE
cloudsql: Remove host CA cert mounting

### DIFF
--- a/cloudsql/mysql_wordpress_deployment.yaml
+++ b/cloudsql/mysql_wordpress_deployment.yaml
@@ -45,8 +45,6 @@ spec:
             - name: cloudsql-instance-credentials
               mountPath: /secrets/cloudsql
               readOnly: true
-            - name: ssl-certs
-              mountPath: /etc/ssl/certs
             - name: cloudsql
               mountPath: /cloudsql
         # [END proxy_container]
@@ -57,7 +55,4 @@ spec:
             secretName: cloudsql-instance-credentials
         - name: cloudsql
           emptyDir:
-        - name: ssl-certs
-          hostPath:
-            path: /etc/ssl/certs
       # [END volumes]

--- a/cloudsql/postgres_deployment.yaml
+++ b/cloudsql/postgres_deployment.yaml
@@ -46,8 +46,6 @@ spec:
             - name: cloudsql-instance-credentials
               mountPath: /secrets/cloudsql
               readOnly: true
-            - name: ssl-certs
-              mountPath: /etc/ssl/certs
             - name: cloudsql
               mountPath: /cloudsql
         # [END proxy_container]
@@ -58,7 +56,4 @@ spec:
             secretName: cloudsql-instance-credentials
         - name: cloudsql
           emptyDir:
-        - name: ssl-certs
-          hostPath:
-            path: /etc/ssl/certs
       # [END volumes]


### PR DESCRIPTION
Since this example was first developed, cloudsql proxy image has started
shipping CA certs installed in the container image. These mounts are no longer
necessary.

cc: @athenashi @piaxc