### PR TITLE
cloudsql: remove --dir=/cloudsql from samples

### DIFF
--- a/cloudsql/mysql_wordpress_deployment.yaml
+++ b/cloudsql/mysql_wordpress_deployment.yaml
@@ -38,15 +38,13 @@ spec:
         # [START proxy_container]
         - name: cloudsql-proxy
           image: gcr.io/cloudsql-docker/gce-proxy:1.11
-          command: ["/cloud_sql_proxy", "--dir=/cloudsql",
+          command: ["/cloud_sql_proxy",
                     "-instances=<INSTANCE_CONNECTION_NAME>=tcp:3306",
                     "-credential_file=/secrets/cloudsql/credentials.json"]
           volumeMounts:
             - name: cloudsql-instance-credentials
               mountPath: /secrets/cloudsql
               readOnly: true
-            - name: cloudsql
-              mountPath: /cloudsql
         # [END proxy_container]
       # [START volumes]
       volumes:

--- a/cloudsql/postgres_deployment.yaml
+++ b/cloudsql/postgres_deployment.yaml
@@ -39,15 +39,13 @@ spec:
         # [START proxy_container]
         - name: cloudsql-proxy
           image: gcr.io/cloudsql-docker/gce-proxy:1.11
-          command: ["/cloud_sql_proxy", "--dir=/cloudsql",
+          command: ["/cloud_sql_proxy",
                     "-instances=<INSTANCE_CONNECTION_NAME>=tcp:5432",
                     "-credential_file=/secrets/cloudsql/credentials.json"]
           volumeMounts:
             - name: cloudsql-instance-credentials
               mountPath: /secrets/cloudsql
               readOnly: true
-            - name: cloudsql
-              mountPath: /cloudsql
         # [END proxy_container]
       # [START volumes]
       volumes:


### PR DESCRIPTION
There was an unused --dir=/cloudsql directive passed to cloudsql image and
the resulted unix socket was not used since the sample makes use of TCP
connection between the app and the cloudsql sidecar container.

cc: @athenashi @piaxc