### PR TITLE
Hide license headers in custom metrics autoscaling samples

### DIFF
--- a/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd-hpa.yaml
+++ b/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd-hpa.yaml
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# [START all]
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -28,4 +30,4 @@ spec:
     pods:
       metricName: foo
       targetAverageValue: 20
-
+# [END all]

--- a/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd.yaml
+++ b/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd.yaml
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# [START all]
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -44,3 +46,4 @@ spec:
               fieldRef:
                 apiVersion: v1
                 fieldPath: metadata.uid
+# [END all]

--- a/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd-hpa.yaml
+++ b/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd-hpa.yaml
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# [START all]
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -50,3 +52,4 @@ spec:
         name: custom-metric-prometheus-sd
       metricName: foo
       targetValue: 20
+# [END all]

--- a/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd.yaml
+++ b/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd.yaml
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# [START all]
 apiVersion: v1
 kind: Pod
 metadata:
@@ -45,3 +47,4 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
+# [END all]


### PR DESCRIPTION
Hide license headers in custom metrics autoscaling samples