### PR TITLE
remove un-used cloudsql volume referenced in cloudsql proxy sample

### DIFF
--- a/cloudsql/mysql_wordpress_deployment.yaml
+++ b/cloudsql/mysql_wordpress_deployment.yaml
@@ -51,6 +51,4 @@ spec:
         - name: cloudsql-instance-credentials
           secret:
             secretName: cloudsql-instance-credentials
-        - name: cloudsql
-          emptyDir:
       # [END volumes]


### PR DESCRIPTION
there is a cloudsql volume that is defined and not mounted anywhere. it does not seem to be used at all.