### PR TITLE
Add HPA to Pub/Sub example

### DIFF
--- a/cloud-pubsub/main.py
+++ b/cloud-pubsub/main.py
@@ -6,6 +6,7 @@ prints to standard output.
 """
 
 import datetime
+import time
 
 from google.cloud import pubsub
 
@@ -22,9 +23,21 @@ def main():
     while True:
         with pubsub.subscription.AutoAck(subscription, max_messages=10) as ack:
             for _, message in list(ack.items()):
-                print("[{0}] ID={1} Data={2}".format(datetime.datetime.now(),
-                                                     message.message_id,
-                                                     message.data))
+                print("[{0}] Received message: ID={1} Data={2}".format(
+                    datetime.datetime.now(),
+                    message.message_id,
+                    message.data))
+                process(message)
+
+
+def process(message):
+    """Process received message"""
+    print("[{0}] Processing: {1}".format(datetime.datetime.now(),
+                                         message.message_id))
+    time.sleep(3)
+    print("[{0}] Processed: {1}".format(datetime.datetime.now(),
+                                        message.message_id))
+
 
 if __name__ == '__main__':
     main()

--- a/cloud-pubsub/pubsub-hpa.yaml
+++ b/cloud-pubsub/pubsub-hpa.yaml
@@ -1,0 +1,19 @@
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: pubsub
+spec:
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+  - external:
+      metricName: pubsub.googleapis.com|subscription|num_undelivered_messages
+      metricSelector:
+        matchLabels:
+          resource.labels.subscription_id: echo-read
+      targetAverageValue: "2"
+    type: External
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: pubsub


### PR DESCRIPTION
This will be used in upcoming HPA external metrics tutorial. Adding sleep to simulate processing time is needed, so it's easy to generate load that a single instance can't handle and trigger autoscaling.