### PR TITLE
Improve custom metric example to handle SIGTERM

### DIFF
--- a/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd.yaml
+++ b/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd.yaml
@@ -31,10 +31,8 @@ spec:
         run: custom-metric-sd
     spec:
       containers:
-      - command:
-        - /bin/sh
-        - -c
-        - ./direct-to-sd --metric-name=foo --metric-value=40 --pod-id=$(POD_ID)
+      - command: ["./direct-to-sd"]
+        args: ["--metric-name=foo", "--metric-value=40", "--pod-id=$(POD_ID)"]
         image: gcr.io/google-samples/sd-dummy-exporter:latest
         name: sd-dummy-exporter
         resources:


### PR DESCRIPTION
Using `/bin/sh -c` to execute `direct-to-sd` we can't handle properly process signals (like SIGTERM).

closes #69 