### PR TITLE
Fix small errors of cloud-pubsub, wordpress-persistent-disks example made from #81 

### DIFF
--- a/cloud-pubsub/deployment/pubsub-with-secret.yaml
+++ b/cloud-pubsub/deployment/pubsub-with-secret.yaml
@@ -3,6 +3,9 @@ kind: Deployment
 metadata:
   name: pubsub
 spec:
+  selector:
+    matchLabels:
+      app: pubsub
   template:
     metadata:
       labels:

--- a/cloud-pubsub/deployment/pubsub.yaml
+++ b/cloud-pubsub/deployment/pubsub.yaml
@@ -3,6 +3,9 @@ kind: Deployment
 metadata:
   name: pubsub
 spec:
+  selector:
+    matchLabels:
+      app: pubsub
   template:
     metadata:
       labels:

--- a/cloud-pubsub/main.py
+++ b/cloud-pubsub/main.py
@@ -10,7 +10,7 @@ import time
 
 from google.cloud import pubsub
 
-PUBSUB_TOPIC = 'eco'
+PUBSUB_TOPIC = 'echo'
 PUBSUB_SUBSCRIPTION = 'echo-read'
 
 

--- a/wordpress-persistent-disks/mysql.yaml
+++ b/wordpress-persistent-disks/mysql.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mysql

--- a/wordpress-persistent-disks/wordpress.yaml
+++ b/wordpress-persistent-disks/wordpress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: wordpress


### PR DESCRIPTION
As #81 upgrading the apiVersion, I got this error when `kubectl create -f pubsub.yaml`   --> `error validating data: ValidationError(Deployment.spec):ent.spec): missing required field "selector" in io.k8s.api.apps.v1.DeploymentSpec`

It seems like It has to explicitly match labels from this version. I just added the field. Also It's not a problem for now, but there is a typo on `main.py`. It seems like the image on gcr is built on top of fixed typo version. 