### PR TITLE
Fix minor readability issues

### DIFF
--- a/hello-app/main.go
+++ b/hello-app/main.go
@@ -25,20 +25,19 @@ import (
 )
 
 func main() {
-	// use PORT environment variable, or default to 8080
-	port := "8080"
-	if fromEnv := os.Getenv("PORT"); fromEnv != "" {
-		port = fromEnv
-	}
-
 	// register hello function to handle all requests
-	server := http.NewServeMux()
-	server.HandleFunc("/", hello)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", hello)
+
+	// use PORT environment variable, or default to 8080
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
 
 	// start the web server on port and accept requests
 	log.Printf("Server listening on port %s", port)
-	err := http.ListenAndServe(":"+port, server)
-	log.Fatal(err)
+	log.Fatal(http.ListenAndServe(":"+port, mux))
 }
 
 // hello responds to the request with a plain-text "Hello, world" message.
@@ -49,4 +48,5 @@ func hello(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "Version: 1.0.0\n")
 	fmt.Fprintf(w, "Hostname: %s\n", host)
 }
+
 // [END all]

--- a/quickstart/go/helloworld.go
+++ b/quickstart/go/helloworld.go
@@ -9,10 +9,12 @@ import (
 
 func main() {
 	http.HandleFunc("/", handler)
+
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "8080"
 	}
+
 	log.Printf("Listening on localhost:%s", port)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%s", port), nil))
 }


### PR DESCRIPTION
- Avoid the intermediate variable names where possible.
- Don't name a ServeMux as a server.
- Move the PORT below where it contextually is more relevant.
- Keep hello-aoo and quickstart consistent.