### PR TITLE
Update custom metrics samples

### DIFF
--- a/cloud-pubsub/deployment/pubsub-hpa.yaml
+++ b/cloud-pubsub/deployment/pubsub-hpa.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START gke_pubsub_hpa]
+# [START gke_pubsub_horizontal_pod_autoscaler]
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -32,4 +32,4 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: pubsub
-# [END gke_pubsub_hpa]
+# [END gke_pubsub_horizontal_pod_autoscaler]

--- a/cloud-pubsub/deployment/pubsub-hpa.yaml
+++ b/cloud-pubsub/deployment/pubsub-hpa.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START gke_pubsub_horizontal_pod_autoscaler]
+# [START kubernetes_engine_pubsub_horizontal_pod_autoscaler]
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -32,4 +32,4 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: pubsub
-# [END gke_pubsub_horizontal_pod_autoscaler]
+# [END kubernetes_engine_pubsub_horizontal_pod_autoscaler]

--- a/cloud-pubsub/deployment/pubsub-hpa.yaml
+++ b/cloud-pubsub/deployment/pubsub-hpa.yaml
@@ -1,3 +1,18 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_pubsub_hpa]
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -17,3 +32,4 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: pubsub
+# [END gke_pubsub_hpa]

--- a/cloud-pubsub/deployment/pubsub-with-secret.yaml
+++ b/cloud-pubsub/deployment/pubsub-with-secret.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START gke_pubsub_secret_deployment]
+# [START kubernetes_engine_pubsub_secret_deployment]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -39,4 +39,4 @@ spec:
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/secrets/google/key.json
-# [END gke_pubsub_secret_deployment]
+# [END kubernetes_engine_pubsub_secret_deployment]

--- a/cloud-pubsub/deployment/pubsub-with-secret.yaml
+++ b/cloud-pubsub/deployment/pubsub-with-secret.yaml
@@ -1,3 +1,18 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_pubsub_secret_deployment]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -24,3 +39,4 @@ spec:
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/secrets/google/key.json
+# [END gke_pubsub_secret_deployment]

--- a/cloud-pubsub/deployment/pubsub.yaml
+++ b/cloud-pubsub/deployment/pubsub.yaml
@@ -1,3 +1,18 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_pubsub_deployment]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -14,3 +29,4 @@ spec:
       containers:
       - name: subscriber
         image: gcr.io/google-samples/pubsub-sample:v1
+# [END gke_pubsub_deployment]

--- a/cloud-pubsub/deployment/pubsub.yaml
+++ b/cloud-pubsub/deployment/pubsub.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START gke_pubsub_deployment]
+# [START kubernetes_engine_pubsub_deployment]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -29,4 +29,4 @@ spec:
       containers:
       - name: subscriber
         image: gcr.io/google-samples/pubsub-sample:v1
-# [END gke_pubsub_deployment]
+# [END kubernetes_engine_pubsub_deployment]

--- a/cloud-pubsub/main.py
+++ b/cloud-pubsub/main.py
@@ -13,7 +13,7 @@ from google.cloud import pubsub
 PUBSUB_TOPIC = 'echo'
 PUBSUB_SUBSCRIPTION = 'echo-read'
 
-# [START gke_pubsub_pull]
+# [START kubernetes_engine_pubsub_pull]
 def main():
     """Continuously pull messages from subsciption"""
     client = pubsub.Client()
@@ -37,7 +37,7 @@ def process(message):
     time.sleep(3)
     print("[{0}] Processed: {1}".format(datetime.datetime.now(),
                                         message.message_id))
-# [END gke_pubsub_pull]
+# [END kubernetes_engine_pubsub_pull]
 
 if __name__ == '__main__':
     main()

--- a/cloud-pubsub/main.py
+++ b/cloud-pubsub/main.py
@@ -13,7 +13,7 @@ from google.cloud import pubsub
 PUBSUB_TOPIC = 'echo'
 PUBSUB_SUBSCRIPTION = 'echo-read'
 
-
+# [START gke_pubsub_pull]
 def main():
     """Continuously pull messages from subsciption"""
     client = pubsub.Client()
@@ -37,7 +37,7 @@ def process(message):
     time.sleep(3)
     print("[{0}] Processed: {1}".format(datetime.datetime.now(),
                                         message.message_id))
-
+# [END gke_pubsub_pull]
 
 if __name__ == '__main__':
     main()

--- a/custom-metrics-autoscaling/direct-to-sd/Dockerfile
+++ b/custom-metrics-autoscaling/direct-to-sd/Dockerfile
@@ -22,4 +22,4 @@ RUN CGO_ENABLED=0 GOOS=linux go install direct-to-sd
 FROM alpine:latest
 RUN apk -U add ca-certificates
 COPY --from=0 /go/bin/direct-to-sd .
-
+ENTRYPOINT ./direct-to-sd

--- a/custom-metrics-autoscaling/direct-to-sd/Dockerfile
+++ b/custom-metrics-autoscaling/direct-to-sd/Dockerfile
@@ -22,4 +22,3 @@ RUN CGO_ENABLED=0 GOOS=linux go install direct-to-sd
 FROM alpine:latest
 RUN apk -U add ca-certificates
 COPY --from=0 /go/bin/direct-to-sd .
-ENTRYPOINT ./direct-to-sd

--- a/custom-metrics-autoscaling/direct-to-sd/README.md
+++ b/custom-metrics-autoscaling/direct-to-sd/README.md
@@ -1,6 +1,7 @@
 # Stackdriver dummy exporter
 
-A simple sd-dummy-exporter container exports a metric of constant value to Stackdriver in a loop. The metric name and value can be passed by flags. Pod ID is also passed by a flag.
+A simple sd-dummy-exporter container exports a metric of constant value to Stackdriver in a loop.
+The metric name and value can be passed by flags. Pod Name and Namespace are also passed by flags.
 
 # Build
 

--- a/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd-hpa.yaml
+++ b/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd-hpa.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START gke_autoscale_stackdriver_horizontal_pod_autoscaler]
+# [START kubernetes_engine_autoscale_stackdriver_horizontal_pod_autoscaler]
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -30,4 +30,4 @@ spec:
     pods:
       metricName: custom-stackdriver
       targetAverageValue: 20
-# [END gke_autoscale_stackdriver_horizontal_pod_autoscaler]
+# [END kubernetes_engine_autoscale_stackdriver_horizontal_pod_autoscaler]

--- a/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd-hpa.yaml
+++ b/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd-hpa.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START gke_autoscale_stackdriver_hpa]
+# [START gke_autoscale_stackdriver_horizontal_pod_autoscaler]
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -30,4 +30,4 @@ spec:
     pods:
       metricName: custom-stackdriver
       targetAverageValue: 20
-# [END gke_autoscale_stackdriver_hpa]
+# [END gke_autoscale_stackdriver_horizontal_pod_autoscaler]

--- a/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd-hpa.yaml
+++ b/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd-hpa.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START kubernetes_engine_autoscale_stackdriver_horizontal_pod_autoscaler]
+# [START kubernetes_engine_custom_metrics_direct_horizontal_pod_autoscaler]
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -30,4 +30,4 @@ spec:
     pods:
       metricName: custom-stackdriver
       targetAverageValue: 20
-# [END kubernetes_engine_autoscale_stackdriver_horizontal_pod_autoscaler]
+# [END kubernetes_engine_custom_metrics_direct_horizontal_pod_autoscaler]

--- a/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd-hpa.yaml
+++ b/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd-hpa.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START all]
+# [START gke_autoscale_stackdriver_hpa]
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -28,6 +28,6 @@ spec:
   metrics:
   - type: Pods
     pods:
-      metricName: foo
+      metricName: custom-stackdriver
       targetAverageValue: 20
-# [END all]
+# [END gke_autoscale_stackdriver_hpa]

--- a/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd.yaml
+++ b/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START gke_autoscale_stackdriver_manifest]
+# [START kubernetes_engine_autoscale_stackdriver_manifest]
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -56,4 +56,4 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-# [END gke_autoscale_stackdriver_manifest]
+# [END kubernetes_engine_autoscale_stackdriver_manifest]

--- a/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd.yaml
+++ b/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd.yaml
@@ -31,15 +31,14 @@ spec:
         run: custom-metric-sd
     spec:
       containers:
-      - command:
-        - /bin/sh
-        - -c
-        - ./sd_dummy_exporter \
-            --metric-name=custom-stackdriver \
-            --metric-value=40 \
-            --use-new-resource-model \
-            --pod-name=$(POD_NAME) \
-            --namespace=$(NAMESPACE)
+      - command: ["./sd_dummy_exporter"]
+        args:
+        - --use-new-resource-model=true
+        - --use-old-resource-model=false
+        - --metric-name=custom-stackdriver
+        - --metric-value=40
+        - --pod-name=$(POD_NAME)
+        - --namespace=$(NAMESPACE)
         image: gcr.io/google-containers/sd-dummy-exporter:v0.2.0
         name: sd-dummy-exporter
         resources:

--- a/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd.yaml
+++ b/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START kubernetes_engine_autoscale_stackdriver_manifest]
+# [START kubernetes_engine_custom_metrics_direct_deployment]
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -56,4 +56,4 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-# [END kubernetes_engine_autoscale_stackdriver_manifest]
+# [END kubernetes_engine_custom_metrics_direct_deployment]

--- a/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd.yaml
+++ b/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd.yaml
@@ -45,14 +45,15 @@ spec:
           requests:
             cpu: 100m
         env:
-          - name: POD_NAME
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.name
-          - name: NAMESPACE
-            valueFrom:
-              fieldRef:
-                apiVersion: v1
-                fieldPath: metadata.namespace
+        # save Kubernetes metadata as environment variables for use in metrics
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
 # [END gke_autoscale_stackdriver_manifest]

--- a/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd.yaml
+++ b/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd.yaml
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START all]
-apiVersion: apps/v1
+# [START gke_autoscale_stackdriver_manifest]
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   labels:
@@ -31,17 +31,29 @@ spec:
         run: custom-metric-sd
     spec:
       containers:
-      - command: ["./direct-to-sd"]
-        args: ["--metric-name=foo", "--metric-value=40", "--pod-id=$(POD_ID)"]
-        image: gcr.io/google-samples/sd-dummy-exporter:latest
+      - command:
+        - /bin/sh
+        - -c
+        - ./sd_dummy_exporter \
+            --metric-name=custom-stackdriver \
+            --metric-value=40 \
+            --use-new-resource-model \
+            --pod-name=$(POD_NAME) \
+            --namespace=$(NAMESPACE)
+        image: gcr.io/google-containers/sd-dummy-exporter:v0.2.0
         name: sd-dummy-exporter
         resources:
           requests:
             cpu: 100m
         env:
-          - name: POD_ID
+          - name: POD_NAME
             valueFrom:
               fieldRef:
                 apiVersion: v1
-                fieldPath: metadata.uid
-# [END all]
+                fieldPath: metadata.name
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+# [END gke_autoscale_stackdriver_manifest]

--- a/custom-metrics-autoscaling/direct-to-sd/sd_dummy_exporter.go
+++ b/custom-metrics-autoscaling/direct-to-sd/sd_dummy_exporter.go
@@ -143,7 +143,7 @@ func getResourceLabelsForNewModel(namespace, name string) map[string]string {
 	}
 }
 
-// [START kubernetes_engine_autoscale_stackdriver_exporter]
+// [START kubernetes_engine_custom_metrics_direct_exporter]
 func exportMetric(stackdriverService *monitoring.Service, metricName string,
 	metricValue int64, metricLabels map[string]string, monitoredResource string, resourceLabels map[string]string) error {
 	dataPoint := &monitoring.Point{
@@ -177,4 +177,4 @@ func exportMetric(stackdriverService *monitoring.Service, metricName string,
 	return err
 }
 
-// [END kubernetes_engine_autoscale_stackdriver_exporter]
+// [END kubernetes_engine_custom_metrics_direct_exporter]

--- a/custom-metrics-autoscaling/direct-to-sd/sd_dummy_exporter.go
+++ b/custom-metrics-autoscaling/direct-to-sd/sd_dummy_exporter.go
@@ -143,7 +143,7 @@ func getResourceLabelsForNewModel(namespace, name string) map[string]string {
 	}
 }
 
-// [START gke_autoscale_stackdriver_exporter]
+// [START kubernetes_engine_autoscale_stackdriver_exporter]
 func exportMetric(stackdriverService *monitoring.Service, metricName string,
 	metricValue int64, metricLabels map[string]string, monitoredResource string, resourceLabels map[string]string) error {
 	dataPoint := &monitoring.Point{
@@ -177,4 +177,4 @@ func exportMetric(stackdriverService *monitoring.Service, metricName string,
 	return err
 }
 
-// [END gke_autoscale_stackdriver_exporter]
+// [END kubernetes_engine_autoscale_stackdriver_exporter]

--- a/custom-metrics-autoscaling/direct-to-sd/sd_dummy_exporter.go
+++ b/custom-metrics-autoscaling/direct-to-sd/sd_dummy_exporter.go
@@ -33,17 +33,35 @@ import (
 
 // SD Dummy Exporter is a testing utility that exports a metric of constant value to Stackdriver
 // in a loop. Metric name and value can be specified with flags 'metric-name' and 'metric-value'.
-// SD Dummy Exporter assumes that it runs as a pod in GCE or GKE cluster, and the pod id is passed
-// to it with 'pod-id' flag (which can be passed to a pod via Downward API).
+// SD Dummy Exporter assumes that it runs as a pod in GCE or GKE cluster, and the pod id, pod name
+// and namespace are passed to it with 'pod-id', 'pod-name' and 'namespace' flags.
+// Pod ID and pod name can be passed to a pod via Downward API.
 func main() {
 	// Gather pod information
 	podId := flag.String("pod-id", "", "pod id")
+	namespace := flag.String("namespace", "", "namespace")
+	podName := flag.String("pod-name", "", "pod name")
 	metricName := flag.String("metric-name", "foo", "custom metric name")
 	metricValue := flag.Int64("metric-value", 0, "custom metric value")
+	metricLabelsArg := flag.String("metric-labels", "bar=1", "custom metric labels")
+	// Whether to use old Stackdriver resource model - use monitored resource "gke_container"
+	// For old resource model, podId flag has to be set.
+	useOldResourceModel := flag.Bool("use-old-resource-model", true, "use old stackdriver resource model")
+	// Whether to use new Stackdriver resource model - use monitored resource "k8s_pod"
+	// For new resource model, podName and namespace flags have to be set.
+	useNewResourceModel := flag.Bool("use-new-resource-model", false, "use new stackdriver resource model")
 	flag.Parse()
 
-	if *podId == "" {
+	if *podId == "" && *useOldResourceModel {
 		log.Fatalf("No pod id specified.")
+	}
+
+	if *podName == "" && *useNewResourceModel {
+		log.Fatalf("No pod name specified.")
+	}
+
+	if *namespace == "" && *useNewResourceModel {
+		log.Fatalf("No pod namespace specified.")
 	}
 
 	stackdriverService, err := getStackDriverService()
@@ -51,13 +69,30 @@ func main() {
 		log.Fatalf("Error getting Stackdriver service: %v", err)
 	}
 
-	labels := getResourceLabels(*podId)
+	metricLabels := make(map[string]string)
+	for _, label := range strings.Split(*metricLabelsArg, ",") {
+		labelParts := strings.Split(label, "=")
+		metricLabels[labelParts[0]] = labelParts[1]
+	}
+
+	oldModelLabels := getResourceLabelsForOldModel(*podId)
+	newModelLabels := getResourceLabelsForNewModel(*namespace, *podName)
 	for {
-		err := exportMetric(stackdriverService, *metricName, *metricValue, labels)
-		if err != nil {
-			log.Printf("Failed to write time series data: %v\n", err)
-		} else {
-			log.Printf("Finished writing time series with value: %v\n", metricValue)
+		if *useOldResourceModel {
+			err := exportMetric(stackdriverService, *metricName, *metricValue, metricLabels, "gke_container", oldModelLabels)
+			if err != nil {
+				log.Printf("Failed to write time series data for old resource model: %v\n", err)
+			} else {
+				log.Printf("Finished writing time series for new resource model with value: %v\n", metricValue)
+			}
+		}
+		if *useNewResourceModel {
+			err := exportMetric(stackdriverService, *metricName, *metricValue, metricLabels, "k8s_pod", newModelLabels)
+			if err != nil {
+				log.Printf("Failed to write time series data for new resource model: %v\n", err)
+			} else {
+				log.Printf("Finished writing time series for new resource model with value: %v\n", metricValue)
+			}
 		}
 		time.Sleep(5000 * time.Millisecond)
 	}
@@ -68,10 +103,10 @@ func getStackDriverService() (*monitoring.Service, error) {
 	return monitoring.New(oauthClient)
 }
 
-// getResourceLabels returns resource labels needed to correctly label metric data
-// exported to StackDriver. Labels contain details on the cluster (name, zone, project id)
-// and pod for which the metric is exported (id)
-func getResourceLabels(podId string) map[string]string {
+// getResourceLabelsForOldModel returns resource labels needed to correctly label metric data
+// exported to StackDriver. Labels contain details on the cluster (project id, name)
+// and pod for which the metric is exported (zone, id).
+func getResourceLabelsForOldModel(podId string) map[string]string {
 	projectId, _ := gce.ProjectID()
 	zone, _ := gce.Zone()
 	clusterName, _ := gce.InstanceAttributeValue("cluster-name")
@@ -90,8 +125,27 @@ func getResourceLabels(podId string) map[string]string {
 	}
 }
 
+// getResourceLabelsForNewModel returns resource labels needed to correctly label metric data
+// exported to StackDriver. Labels contain details on the cluster (project id, location, name)
+// and pod for which the metric is exported (namespace, name).
+func getResourceLabelsForNewModel(namespace, name string) map[string]string {
+	projectId, _ := gce.ProjectID()
+	location, _ := gce.InstanceAttributeValue("cluster-location")
+	location = strings.TrimSpace(location)
+	clusterName, _ := gce.InstanceAttributeValue("cluster-name")
+	clusterName = strings.TrimSpace(clusterName)
+	return map[string]string{
+		"project_id":     projectId,
+		"location":       location,
+		"cluster_name":   clusterName,
+		"namespace_name": namespace,
+		"pod_name":       name,
+	}
+}
+
+// [START gke_autoscale_stackdriver_exporter]
 func exportMetric(stackdriverService *monitoring.Service, metricName string,
-	metricValue int64, resourceLabels map[string]string) error {
+	metricValue int64, metricLabels map[string]string, monitoredResource string, resourceLabels map[string]string) error {
 	dataPoint := &monitoring.Point{
 		Interval: &monitoring.TimeInterval{
 			EndTime: time.Now().Format(time.RFC3339),
@@ -105,10 +159,11 @@ func exportMetric(stackdriverService *monitoring.Service, metricName string,
 		TimeSeries: []*monitoring.TimeSeries{
 			{
 				Metric: &monitoring.Metric{
-					Type: "custom.googleapis.com/" + metricName,
+					Type:   "custom.googleapis.com/" + metricName,
+					Labels: metricLabels,
 				},
 				Resource: &monitoring.MonitoredResource{
-					Type:   "gke_container",
+					Type:   monitoredResource,
 					Labels: resourceLabels,
 				},
 				Points: []*monitoring.Point{
@@ -121,3 +176,5 @@ func exportMetric(stackdriverService *monitoring.Service, metricName string,
 	_, err := stackdriverService.Projects.TimeSeries.Create(projectName, request).Do()
 	return err
 }
+
+// [END gke_autoscale_stackdriver_exporter]

--- a/custom-metrics-autoscaling/prometheus-to-sd/Dockerfile
+++ b/custom-metrics-autoscaling/prometheus-to-sd/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.7.3
+FROM golang:1.12.5
 ADD . /go/src/prometheus-dummy-exporter
 RUN go get github.com/prometheus/client_golang/prometheus
 RUN CGO_ENABLED=0 GOOS=linux go install prometheus-dummy-exporter

--- a/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd-hpa.yaml
+++ b/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd-hpa.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START kubernetes_engine_autoscale_prometheus_horizontal_pod_autoscaler]
+# [START kubernetes_engine_custom_metrics_prometheus_horizontal_pod_autoscaler]
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -30,4 +30,4 @@ spec:
     pods:
       metricName: custom_prometheus
       targetAverageValue: 20
-# [END kubernetes_engine_autoscale_prometheus_horizontal_pod_autoscaler]
+# [END kubernetes_engine_custom_metrics_prometheus_horizontal_pod_autoscaler]

--- a/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd-hpa.yaml
+++ b/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd-hpa.yaml
@@ -13,43 +13,21 @@
 # limitations under the License.
 
 # [START gke_autoscale_prometheus_hpa]
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: dummy-deployment
-spec:
-  replicas: 2
-  selector:
-    matchLabels:
-      k8s-app: dummy-deployment
-  template:
-    metadata:
-      labels:
-        k8s-app: dummy-deployment
-    spec:
-      containers:
-      - name: long
-        image: busybox
-        command: ["/bin/sh",  "-c", "sleep 180000000"]
----
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: dummy-deployment-hpa
+  name: custom-prometheus-hpa
   namespace: default
 spec:
   scaleTargetRef:
     apiVersion: apps/v1beta1
     kind: Deployment
-    name: dummy-deployment
+    name: custom-metric-prometheus-sd
   minReplicas: 1
   maxReplicas: 5
   metrics:
-  - type: Object
-    object:
-      target:
-        kind: Pod
-        name: custom-metric-prometheus-sd
-      metricName: foo
-      targetValue: 20
+  - type: Pods
+    pods:
+      metricName: custom_prometheus
+      targetAverageValue: 20
 # [END gke_autoscale_prometheus_hpa]

--- a/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd-hpa.yaml
+++ b/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd-hpa.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START gke_autoscale_prometheus_hpa]
+# [START gke_autoscale_prometheus_horizontal_pod_autoscaler]
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -30,4 +30,4 @@ spec:
     pods:
       metricName: custom_prometheus
       targetAverageValue: 20
-# [END gke_autoscale_prometheus_hpa]
+# [END gke_autoscale_prometheus_horizontal_pod_autoscaler]

--- a/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd-hpa.yaml
+++ b/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd-hpa.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START gke_autoscale_prometheus_horizontal_pod_autoscaler]
+# [START kubernetes_engine_autoscale_prometheus_horizontal_pod_autoscaler]
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -30,4 +30,4 @@ spec:
     pods:
       metricName: custom_prometheus
       targetAverageValue: 20
-# [END gke_autoscale_prometheus_horizontal_pod_autoscaler]
+# [END kubernetes_engine_autoscale_prometheus_horizontal_pod_autoscaler]

--- a/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd-hpa.yaml
+++ b/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd-hpa.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START all]
+# [START gke_autoscale_prometheus_hpa]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -52,4 +52,4 @@ spec:
         name: custom-metric-prometheus-sd
       metricName: foo
       targetValue: 20
-# [END all]
+# [END gke_autoscale_prometheus_hpa]

--- a/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd.yaml
+++ b/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd.yaml
@@ -50,6 +50,7 @@ spec:
         - --pod-id=$(POD_ID)
         - --namespace-id=$(POD_NAMESPACE)
         env:
+        # save Kubernetes metadata as environment variables for use in metrics
         - name: POD_ID
           valueFrom:
             fieldRef:

--- a/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd.yaml
+++ b/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd.yaml
@@ -31,17 +31,16 @@ spec:
         run: custom-metric-prometheus-sd
     spec:
       containers:
-      - command: ["./prometheus_dummy_exporter"]
+      # sample container generating custom metrics
+      - name: prometheus-dummy-exporter
+        image: gcr.io/google-containers/prometheus-dummy-exporter:v0.1.0
+        command: ["./prometheus_dummy_exporter"]
         args:
         - --metric-name=custom_prometheus
         - --metric-value=40
         - --port=8080
-        image: gcr.io/google-containers/prometheus-dummy-exporter:v0.1.0
-        imagePullPolicy: Always
-        name: prometheus-dummy-exporter
-        resources:
-          requests:
-            cpu: 100m
+      # pre-built 'prometheus-to-sd' sidecar container to export prometheus
+      # metrics to Stackdriver
       - name: prometheus-to-sd
         image: gcr.io/google-containers/prometheus-to-sd:v0.5.0
         command: ["/monitor"]

--- a/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd.yaml
+++ b/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START kubernetes_engine_autoscale_prometheus_manifest]
+# [START kubernetes_engine_custom_metrics_prometheus_deployment]
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -60,4 +60,4 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-# [END kubernetes_engine_autoscale_prometheus_manifest]
+# [END kubernetes_engine_custom_metrics_prometheus_deployment]

--- a/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd.yaml
+++ b/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd.yaml
@@ -13,38 +13,51 @@
 # limitations under the License.
 
 # [START gke_autoscale_prometheus_manifest]
-apiVersion: v1
-kind: Pod
+apiVersion: extensions/v1beta1
+kind: Deployment
 metadata:
+  labels:
+    run: custom-metric-prometheus-sd
   name: custom-metric-prometheus-sd
+  namespace: default
 spec:
-  containers:
-  - command:
-    - /bin/sh
-    - -c
-    - ./prometheus-dummy-exporter --metric-name=foo --metric-value=40 --port=8080
-    image: gcr.io/google-samples/prometheus-dummy-exporter:latest
-    imagePullPolicy: Always
-    name: prometheus-dummy-exporter
-    resources:
-      requests:
-        cpu: 100m
-  - name: prometheus-to-sd
-    image: gcr.io/google-containers/prometheus-to-sd:v0.5.0
-    command:
-    - /monitor
-    - --source=:http://localhost:8080
-    - --stackdriver-prefix=custom.googleapis.com
-    - --pod-id=$(POD_ID)
-    - --namespace-id=$(POD_NAMESPACE)
-    env:
-    - name: POD_ID
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: metadata.uid
-    - name: POD_NAMESPACE
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.namespace
+  replicas: 1
+  selector:
+    matchLabels:
+      run: custom-metric-prometheus-sd
+  template:
+    metadata:
+      labels:
+        run: custom-metric-prometheus-sd
+    spec:
+      containers:
+      - command: ["./prometheus_dummy_exporter"]
+        args:
+        - --metric-name=custom_prometheus
+        - --metric-value=40
+        - --port=8080
+        image: gcr.io/google-containers/prometheus-dummy-exporter:v0.1.0
+        imagePullPolicy: Always
+        name: prometheus-dummy-exporter
+        resources:
+          requests:
+            cpu: 100m
+      - name: prometheus-to-sd
+        image: gcr.io/google-containers/prometheus-to-sd:v0.5.0
+        command: ["/monitor"]
+        args:
+        - --source=:http://localhost:8080
+        - --stackdriver-prefix=custom.googleapis.com
+        - --pod-id=$(POD_ID)
+        - --namespace-id=$(POD_NAMESPACE)
+        env:
+        - name: POD_ID
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.uid
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
 # [END gke_autoscale_prometheus_manifest]

--- a/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd.yaml
+++ b/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START all]
+# [START gke_autoscale_prometheus_manifest]
 apiVersion: v1
 kind: Pod
 metadata:
@@ -47,4 +47,4 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.namespace
-# [END all]
+# [END gke_autoscale_prometheus_manifest]

--- a/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd.yaml
+++ b/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START gke_autoscale_prometheus_manifest]
+# [START kubernetes_engine_autoscale_prometheus_manifest]
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -60,4 +60,4 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-# [END gke_autoscale_prometheus_manifest]
+# [END kubernetes_engine_autoscale_prometheus_manifest]

--- a/custom-metrics-autoscaling/prometheus-to-sd/prometheus_dummy_exporter.go
+++ b/custom-metrics-autoscaling/prometheus-to-sd/prometheus_dummy_exporter.go
@@ -35,7 +35,7 @@ func main() {
 	port := flag.Int64("port", 8080, "port to expose metrics on")
 	flag.Parse()
 
-	// [START gke_autoscale_prometheus_exporter]
+	// [START kubernetes_engine_autoscale_prometheus_exporter]
 	metric := prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: *metricName,
@@ -48,6 +48,6 @@ func main() {
 	http.Handle("/metrics", promhttp.Handler())
 	log.Printf("Starting to listen on :%d", *port)
 	err := http.ListenAndServe(fmt.Sprintf(":%d", *port), nil)
-	// [END gke_autoscale_prometheus_exporter]
+	// [END kubernetes_engine_autoscale_prometheus_exporter]
 	log.Fatal("Failed to start serving metrics: %v", err)
 }

--- a/custom-metrics-autoscaling/prometheus-to-sd/prometheus_dummy_exporter.go
+++ b/custom-metrics-autoscaling/prometheus-to-sd/prometheus_dummy_exporter.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // Prometheus Dummy Exporter is a testing utility that exposes a prometheus format metric of constant value.
@@ -44,7 +45,7 @@ func main() {
 	prometheus.MustRegister(metric)
 	metric.Set(float64(*metricValue))
 
-	http.Handle("/metrics", prometheus.Handler())
+	http.Handle("/metrics", promhttp.Handler())
 	log.Printf("Starting to listen on :%d", *port)
 	err := http.ListenAndServe(fmt.Sprintf(":%d", *port), nil)
 	// [END gke_autoscale_prometheus_exporter]

--- a/custom-metrics-autoscaling/prometheus-to-sd/prometheus_dummy_exporter.go
+++ b/custom-metrics-autoscaling/prometheus-to-sd/prometheus_dummy_exporter.go
@@ -35,7 +35,7 @@ func main() {
 	port := flag.Int64("port", 8080, "port to expose metrics on")
 	flag.Parse()
 
-	// [START kubernetes_engine_autoscale_prometheus_exporter]
+	// [START kubernetes_engine_custom_metrics_prometheus_exporter]
 	metric := prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: *metricName,
@@ -48,6 +48,6 @@ func main() {
 	http.Handle("/metrics", promhttp.Handler())
 	log.Printf("Starting to listen on :%d", *port)
 	err := http.ListenAndServe(fmt.Sprintf(":%d", *port), nil)
-	// [END kubernetes_engine_autoscale_prometheus_exporter]
+	// [END kubernetes_engine_custom_metrics_prometheus_exporter]
 	log.Fatal("Failed to start serving metrics: %v", err)
 }

--- a/custom-metrics-autoscaling/prometheus-to-sd/prometheus_dummy_exporter.go
+++ b/custom-metrics-autoscaling/prometheus-to-sd/prometheus_dummy_exporter.go
@@ -34,6 +34,7 @@ func main() {
 	port := flag.Int64("port", 8080, "port to expose metrics on")
 	flag.Parse()
 
+	// [START gke_autoscale_prometheus_exporter]
 	metric := prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: *metricName,
@@ -46,5 +47,6 @@ func main() {
 	http.Handle("/metrics", prometheus.Handler())
 	log.Printf("Starting to listen on :%d", *port)
 	err := http.ListenAndServe(fmt.Sprintf(":%d", *port), nil)
+	// [END gke_autoscale_prometheus_exporter]
 	log.Fatal("Failed to start serving metrics: %v", err)
 }

--- a/hello-app/main.go
+++ b/hello-app/main.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-// [START all]
+// [START gke_hello_app]
 package main
 
 import (
@@ -49,4 +49,4 @@ func hello(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "Hostname: %s\n", host)
 }
 
-// [END all]
+// [END gke_hello_app]

--- a/hello-app/main.go
+++ b/hello-app/main.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-// [START gke_hello_app]
+// [START kubernetes_engine_hello_app]
 package main
 
 import (
@@ -49,4 +49,4 @@ func hello(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "Hostname: %s\n", host)
 }
 
-// [END gke_hello_app]
+// [END kubernetes_engine_hello_app]

--- a/hello-app/manifests/helloweb-deployment.yaml
+++ b/hello-app/manifests/helloweb-deployment.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START gke_helloapp_deployment]
+# [START kubernetes_engine_helloapp_deployment]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -35,4 +35,4 @@ spec:
         image: gcr.io/google-samples/hello-app:1.0
         ports:
         - containerPort: 8080
-# [END gke_helloapp_deployment]
+# [END kubernetes_engine_helloapp_deployment]

--- a/hello-app/manifests/helloweb-deployment.yaml
+++ b/hello-app/manifests/helloweb-deployment.yaml
@@ -1,3 +1,18 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_helloapp_deployment]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -20,3 +35,4 @@ spec:
         image: gcr.io/google-samples/hello-app:1.0
         ports:
         - containerPort: 8080
+# [END gke_helloapp_deployment]

--- a/hello-app/manifests/helloweb-hpa.yaml
+++ b/hello-app/manifests/helloweb-hpa.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START gke_helloapp_hpa]
+# [START gke_helloapp_horizontal_pod_autoscaler]
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -29,4 +29,4 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: helloweb
-# [END gke_helloapp_hpa]
+# [END gke_helloapp_horizontal_pod_autoscaler]

--- a/hello-app/manifests/helloweb-hpa.yaml
+++ b/hello-app/manifests/helloweb-hpa.yaml
@@ -1,3 +1,4 @@
+# [START gke_helloapp_hpa]
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -14,3 +15,4 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: helloweb
+# [END gke_helloapp_hpa]

--- a/hello-app/manifests/helloweb-hpa.yaml
+++ b/hello-app/manifests/helloweb-hpa.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # [START gke_helloapp_hpa]
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler

--- a/hello-app/manifests/helloweb-hpa.yaml
+++ b/hello-app/manifests/helloweb-hpa.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START gke_helloapp_horizontal_pod_autoscaler]
+# [START kubernetes_engine_helloapp_horizontal_pod_autoscaler]
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -29,4 +29,4 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: helloweb
-# [END gke_helloapp_horizontal_pod_autoscaler]
+# [END kubernetes_engine_helloapp_horizontal_pod_autoscaler]

--- a/hello-app/manifests/helloweb-hpa.yaml
+++ b/hello-app/manifests/helloweb-hpa.yaml
@@ -1,0 +1,16 @@
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: cpu
+spec:
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      targetAverageUtilization: 30
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: helloweb

--- a/hello-app/manifests/helloweb-ingress-static-ip.yaml
+++ b/hello-app/manifests/helloweb-ingress-static-ip.yaml
@@ -1,3 +1,18 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_helloapp_ingress]
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -25,3 +40,4 @@ spec:
   ports:
   - port: 8080
     targetPort: 8080
+# [END gke_helloapp_ingress]

--- a/hello-app/manifests/helloweb-ingress-static-ip.yaml
+++ b/hello-app/manifests/helloweb-ingress-static-ip.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START gke_helloapp_ingress]
+# [START kubernetes_engine_helloapp_ingress]
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -40,4 +40,4 @@ spec:
   ports:
   - port: 8080
     targetPort: 8080
-# [END gke_helloapp_ingress]
+# [END kubernetes_engine_helloapp_ingress]

--- a/hello-app/manifests/helloweb-service-static-ip.yaml
+++ b/hello-app/manifests/helloweb-service-static-ip.yaml
@@ -1,3 +1,18 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_helloapp_service]
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,3 +28,4 @@ spec:
     targetPort: 8080
   type: LoadBalancer
   loadBalancerIP: "YOUR.IP.ADDRESS.HERE"
+# [END gke_helloapp_service]

--- a/hello-app/manifests/helloweb-service-static-ip.yaml
+++ b/hello-app/manifests/helloweb-service-static-ip.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START gke_helloapp_service]
+# [START kubernetes_engine_helloapp_service]
 apiVersion: v1
 kind: Service
 metadata:
@@ -28,4 +28,4 @@ spec:
     targetPort: 8080
   type: LoadBalancer
   loadBalancerIP: "YOUR.IP.ADDRESS.HERE"
-# [END gke_helloapp_service]
+# [END kubernetes_engine_helloapp_service]


### PR DESCRIPTION
We have a number of open issues around the [custom metrics autoscaling tutorials](https://cloud.devsite.corp.google.com/kubernetes-engine/docs/tutorials/external-metrics-autoscaling). I'm hoping to do a re-write, but I need some changes to the samples here first:

- Brought the code up to date with the code in the [k8s-stackdriver repo](https://github.com/GoogleCloudPlatform/k8s-stackdriver/tree/4e4016c382a0daf38e331e556e34518c233c2acd/custom-metrics-stackdriver-adapter/examples). This should add support for the [new resource model](https://github.com/GoogleCloudPlatform/k8s-stackdriver/tree/4e4016c382a0daf38e331e556e34518c233c2acd/custom-metrics-stackdriver-adapter/examples/direct-to-sd#stackdriver-dummy-exporter), which is missing from the current tutorial
- fixed custom-prometheus Dockerfile so container will build again
- updated manifests to use tagged images, distinct metric names, and better line breaks
- added region tags and license headers to all samples that will be pulled into the updated tutorial (and others in the same directory for consistency)

Let me know if you have thoughts on the region tag format, since afaik this is the first scoped set in the repo (`gke_*`, `kubernetes_engine_*`, or `google_kubernetes_engine_*`?)