### PR TITLE
Update region tag prefix

### DIFF
--- a/cloud-pubsub/deployment/pubsub-hpa.yaml
+++ b/cloud-pubsub/deployment/pubsub-hpa.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START kubernetes_engine_pubsub_horizontal_pod_autoscaler]
+# [START container_pubsub_horizontal_pod_autoscaler]
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -32,4 +32,4 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: pubsub
-# [END kubernetes_engine_pubsub_horizontal_pod_autoscaler]
+# [END container_pubsub_horizontal_pod_autoscaler]

--- a/cloud-pubsub/deployment/pubsub-with-secret.yaml
+++ b/cloud-pubsub/deployment/pubsub-with-secret.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START kubernetes_engine_pubsub_secret_deployment]
+# [START container_pubsub_secret_deployment]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -39,4 +39,4 @@ spec:
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /var/secrets/google/key.json
-# [END kubernetes_engine_pubsub_secret_deployment]
+# [END container_pubsub_secret_deployment]

--- a/cloud-pubsub/deployment/pubsub.yaml
+++ b/cloud-pubsub/deployment/pubsub.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START kubernetes_engine_pubsub_deployment]
+# [START container_pubsub_deployment]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -29,4 +29,4 @@ spec:
       containers:
       - name: subscriber
         image: gcr.io/google-samples/pubsub-sample:v1
-# [END kubernetes_engine_pubsub_deployment]
+# [END container_pubsub_deployment]

--- a/cloud-pubsub/main.py
+++ b/cloud-pubsub/main.py
@@ -13,7 +13,7 @@ from google.cloud import pubsub
 PUBSUB_TOPIC = 'echo'
 PUBSUB_SUBSCRIPTION = 'echo-read'
 
-# [START kubernetes_engine_pubsub_pull]
+# [START container_pubsub_pull]
 def main():
     """Continuously pull messages from subsciption"""
     client = pubsub.Client()
@@ -37,7 +37,7 @@ def process(message):
     time.sleep(3)
     print("[{0}] Processed: {1}".format(datetime.datetime.now(),
                                         message.message_id))
-# [END kubernetes_engine_pubsub_pull]
+# [END container_pubsub_pull]
 
 if __name__ == '__main__':
     main()

--- a/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd-hpa.yaml
+++ b/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd-hpa.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START kubernetes_engine_custom_metrics_direct_horizontal_pod_autoscaler]
+# [START container_custom_metrics_direct_horizontal_pod_autoscaler]
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -30,4 +30,4 @@ spec:
     pods:
       metricName: custom-metric
       targetAverageValue: 20
-# [END kubernetes_engine_custom_metrics_direct_horizontal_pod_autoscaler]
+# [END container_custom_metrics_direct_horizontal_pod_autoscaler]

--- a/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd.yaml
+++ b/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START kubernetes_engine_custom_metrics_direct_deployment]
+# [START container_custom_metrics_direct_deployment]
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -56,4 +56,4 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-# [END kubernetes_engine_custom_metrics_direct_deployment]
+# [END container_custom_metrics_direct_deployment]

--- a/custom-metrics-autoscaling/direct-to-sd/sd_dummy_exporter.go
+++ b/custom-metrics-autoscaling/direct-to-sd/sd_dummy_exporter.go
@@ -143,7 +143,7 @@ func getResourceLabelsForNewModel(namespace, name string) map[string]string {
 	}
 }
 
-// [START kubernetes_engine_custom_metrics_direct_exporter]
+// [START container_custom_metrics_direct_exporter]
 func exportMetric(stackdriverService *monitoring.Service, metricName string,
 	metricValue int64, metricLabels map[string]string, monitoredResource string, resourceLabels map[string]string) error {
 	dataPoint := &monitoring.Point{
@@ -177,4 +177,4 @@ func exportMetric(stackdriverService *monitoring.Service, metricName string,
 	return err
 }
 
-// [END kubernetes_engine_custom_metrics_direct_exporter]
+// [END container_custom_metrics_direct_exporter]

--- a/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd-hpa.yaml
+++ b/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd-hpa.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START kubernetes_engine_custom_metrics_prometheus_horizontal_pod_autoscaler]
+# [START container_custom_metrics_prometheus_horizontal_pod_autoscaler]
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -30,4 +30,4 @@ spec:
     pods:
       metricName: custom_prometheus
       targetAverageValue: 20
-# [END kubernetes_engine_custom_metrics_prometheus_horizontal_pod_autoscaler]
+# [END container_custom_metrics_prometheus_horizontal_pod_autoscaler]

--- a/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd.yaml
+++ b/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START kubernetes_engine_custom_metrics_prometheus_deployment]
+# [START container_custom_metrics_prometheus_deployment]
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -60,4 +60,4 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-# [END kubernetes_engine_custom_metrics_prometheus_deployment]
+# [END container_custom_metrics_prometheus_deployment]

--- a/custom-metrics-autoscaling/prometheus-to-sd/prometheus_dummy_exporter.go
+++ b/custom-metrics-autoscaling/prometheus-to-sd/prometheus_dummy_exporter.go
@@ -35,7 +35,7 @@ func main() {
 	port := flag.Int64("port", 8080, "port to expose metrics on")
 	flag.Parse()
 
-	// [START kubernetes_engine_custom_metrics_prometheus_exporter]
+	// [START container_custom_metrics_prometheus_exporter]
 	metric := prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Name: *metricName,
@@ -48,6 +48,6 @@ func main() {
 	http.Handle("/metrics", promhttp.Handler())
 	log.Printf("Starting to listen on :%d", *port)
 	err := http.ListenAndServe(fmt.Sprintf(":%d", *port), nil)
-	// [END kubernetes_engine_custom_metrics_prometheus_exporter]
+	// [END container_custom_metrics_prometheus_exporter]
 	log.Fatal("Failed to start serving metrics: %v", err)
 }

--- a/hello-app/main.go
+++ b/hello-app/main.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-// [START kubernetes_engine_hello_app]
+// [START container_hello_app]
 package main
 
 import (
@@ -49,4 +49,4 @@ func hello(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "Hostname: %s\n", host)
 }
 
-// [END kubernetes_engine_hello_app]
+// [END container_hello_app]

--- a/hello-app/manifests/helloweb-deployment.yaml
+++ b/hello-app/manifests/helloweb-deployment.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START kubernetes_engine_helloapp_deployment]
+# [START container_helloapp_deployment]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -35,4 +35,4 @@ spec:
         image: gcr.io/google-samples/hello-app:1.0
         ports:
         - containerPort: 8080
-# [END kubernetes_engine_helloapp_deployment]
+# [END container_helloapp_deployment]

--- a/hello-app/manifests/helloweb-hpa.yaml
+++ b/hello-app/manifests/helloweb-hpa.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START kubernetes_engine_helloapp_horizontal_pod_autoscaler]
+# [START container_helloapp_horizontal_pod_autoscaler]
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -29,4 +29,4 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: helloweb
-# [END kubernetes_engine_helloapp_horizontal_pod_autoscaler]
+# [END container_helloapp_horizontal_pod_autoscaler]

--- a/hello-app/manifests/helloweb-ingress-static-ip.yaml
+++ b/hello-app/manifests/helloweb-ingress-static-ip.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START kubernetes_engine_helloapp_ingress]
+# [START container_helloapp_ingress]
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -40,4 +40,4 @@ spec:
   ports:
   - port: 8080
     targetPort: 8080
-# [END kubernetes_engine_helloapp_ingress]
+# [END container_helloapp_ingress]

--- a/hello-app/manifests/helloweb-service-static-ip.yaml
+++ b/hello-app/manifests/helloweb-service-static-ip.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START kubernetes_engine_helloapp_service]
+# [START container_helloapp_service]
 apiVersion: v1
 kind: Service
 metadata:
@@ -28,4 +28,4 @@ spec:
     targetPort: 8080
   type: LoadBalancer
   loadBalancerIP: "YOUR.IP.ADDRESS.HERE"
-# [END kubernetes_engine_helloapp_service]
+# [END container_helloapp_service]


### PR DESCRIPTION
I used `kubernetes_engine` as the prefix to our region tags, but they weren't being picked up by the samples tracker. It looks like the expected GKE prefix is `container`