### PR TITLE
add gke-whereami to samples

### DIFF
--- a/gke-whereami/Dockerfile
+++ b/gke-whereami/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.8-alpine
+
+#MAINTAINER Alex Mattson "alex.mattson@gmail.com"
+# test
+
+COPY ./requirements.txt /app/requirements.txt
+
+WORKDIR /app
+
+RUN pip install -r requirements.txt
+
+COPY . /app
+
+RUN addgroup -S appuser && adduser -S -G appuser appuser
+USER appuser
+
+ENTRYPOINT [ "python" ]
+
+CMD [ "app.py" ]

--- a/gke-whereami/Dockerfile
+++ b/gke-whereami/Dockerfile
@@ -1,7 +1,6 @@
 FROM python:3.8-alpine
 
 #MAINTAINER Alex Mattson "alex.mattson@gmail.com"
-# test
 
 COPY ./requirements.txt /app/requirements.txt
 

--- a/gke-whereami/Procfile
+++ b/gke-whereami/Procfile
@@ -1,0 +1,1 @@
+web: python app.py

--- a/gke-whereami/README.md
+++ b/gke-whereami/README.md
@@ -1,0 +1,85 @@
+# gke-whereami
+
+A simple Kubernetes-oriented app for describing the location of the pod serving a request via its attributes (cluster name, cluster region, pod name, namespace, service account, etc). The response payload includes an emoji that is hashed from the pod name, which makes it a little easier for a human to visually identify the pod you're dealing with.
+
+This was originally written for testing & debugging multi-cluster ingress use cases on GKE (now Ingress for Anthos).
+
+### Setup
+
+Create a GKE cluster 
+
+First define your environment variables (substituting where #needed#):
+
+```
+export PROJECT_ID=#YOUR_PROJECT_ID#
+
+export COMPUTE_REGION=#YOUR_COMPUTE_REGION#
+
+export CLUSTER_NAME=whereami
+```
+
+Now create your resources:
+
+```
+gcloud beta container clusters create $CLUSTER_NAME \
+  --enable-ip-alias \
+  --enable-stackdriver-kubernetes \
+  --region=$COMPUTE_REGION \
+  --num-nodes=1 \
+  --release-channel=regular
+
+gcloud container clusters get-credentials $CLUSTER_NAME --region $COMPUTE_REGION
+```
+
+Deploy the service/pods:
+
+```kubectl apply -k k8s```
+
+*or*
+
+```kustomize build k8s | kubectl apply -f -```
+
+Get the service endpoint:
+```
+WHEREAMI_ENDPOINT=$(kubectl get svc | grep -v EXTERNAL-IP | awk '{ print $4}')
+```
+
+Wrap things up by `curl`ing the `EXTERNAL-IP` of the service. 
+
+```curl $WHEREAMI_ENDPOINT -H "Host: hello"```
+
+Result:
+
+```{"cluster_name":"cluster-1","host_header":"34.66.118.115","id_string":"frontend","node_name":"gke-cluster-1-default-pool-c91b5644-v8kg.c.alexmattson-scratch.internal","pod_ip":"10.4.2.15","pod_name":"whereami-c657c68f5-9jtkw","pod_name_emoji":"👇","pod_namespace":"default","pod_service_account":"whereami-ksa","project_id":"alexmattson-scratch","timestamp":"2020-07-29T19:08:31","zone":"us-central1-c"}```
+
+
+#### using gke-whereami to call downstream services 
+
+`gke-whereami` has an optional flag within its configmap that will cause it to attempt to call another backend service within your GKE cluster (for example, a different, non-public instance of itself). This is helpful for demonstrating a public microservice call to a non-public microservice, and then including the responses of both microservices in the payload delivered back to the user.  
+
+*NOTE:* this backend call assumes the downstream service is returning JSON.
+
+First, build the "backend" instance of `gke-whereami`:
+
+```kustomize build k8s-backend-overlay-example | kubectl apply -f -```
+
+*or*
+
+```kubectl apply -k k8s-backend-overlay-example```
+
+Once that service is up and running, modify `k8s/configmap.yaml`'s `BACKEND_ENABLED` to `"True"`. You will have to redeploy the pods in the whereami service as they will not automatically be recreated when you update the configmap.
+
+The (*slightly* busy-looking) result should look like this:
+
+```{"backend_result":{"cluster_name":"cluster-1","host_header":"whereami-backend","id_string":"backend","node_name":"gke-cluster-1-default-pool-c91b5644-q7w5.c.alexmattson-scratch.internal","pod_ip":"10.4.0.10","pod_name":"whereami-backend-966547575-nk9df","pod_name_emoji":"📔","pod_namespace":"default","pod_service_account":"whereami-ksa-backend","project_id":"alexmattson-scratch","timestamp":"2020-07-29T19:32:15","zone":"us-central1-c"},"cluster_name":"cluster-1","host_header":"34.72.90.134","id_string":"frontend","node_name":"gke-cluster-1-default-pool-c91b5644-v8kg.c.alexmattson-scratch.internal","pod_ip":"10.4.2.16","pod_name":"whereami-c657c68f5-r65s5","pod_name_emoji":"🌋","pod_namespace":"default","pod_service_account":"whereami-ksa","project_id":"alexmattson-scratch","timestamp":"2020-07-29T19:32:15","zone":"us-central1-c"}```
+
+If you wish to call a different backend service, modify `k8s/configmap.yaml`'s `BACKEND_SERVICE` to some other service name. 
+
+
+#### Notes
+
+The operating port of the pod has been switched from `5000` to `8080` to work easily with the managed version of Cloud Run.
+
+If you'd like to build & publish via Google's buildpacks, something like this should do the trick (leveraging the local `Procfile`:
+
+```pack build --builder gcr.io/buildpacks/builder:v1 --publish gcr.io/${PROJECT_ID}/whereami```

--- a/gke-whereami/README.md
+++ b/gke-whereami/README.md
@@ -35,11 +35,15 @@ This will create a regional cluster with a single node per zone (3 nodes in tota
 
 #### Step 2 - Deploy the service/pods:
 
-```kubectl apply -k k8s```
+```
+kubectl apply -k k8s
+```
 
 *or via [kustomize](https://kustomize.io/)*
 
-```kustomize build k8s | kubectl apply -f -```
+```
+kustomize build k8s | kubectl apply -f -
+```
 
 Get the service endpoint:
 ```
@@ -48,44 +52,52 @@ WHEREAMI_ENDPOINT=$(kubectl get svc | grep -v EXTERNAL-IP | awk '{ print $4}')
 
 Wrap things up by `curl`ing the `EXTERNAL-IP` of the service. 
 
-```curl $WHEREAMI_ENDPOINT```
+```
+curl $WHEREAMI_ENDPOINT
+```
 
 Result:
 
 ```{"cluster_name":"cluster-1","host_header":"34.72.90.134","metadata":"frontend","node_name":"gke-cluster-1-default-pool-c91b5644-v8kg.c.alexmattson-scratch.internal","pod_ip":"10.4.2.34","pod_name":"whereami-7b79956dd6-vmm9z","pod_name_emoji":"🧚🏼‍♀️","pod_namespace":"default","pod_service_account":"whereami-ksa","project_id":"alexmattson-scratch","timestamp":"2020-07-30T05:44:14","zone":"us-central1-c"}```
 
+### [Optional] Setup backend service call
 
-#### Step 3 - [Optional] Use gke-whereami to call downstream services 
+`gke-whereami` has an optional flag within its configmap that will cause it to call another backend service within your GKE cluster (for example, a different, non-public instance of itself). This is helpful for demonstrating a public microservice call to a non-public microservice, and then including the responses of both microservices in the payload delivered back to the user.
 
-`gke-whereami` has an optional flag within its configmap that will cause it to call another backend service within your GKE cluster (for example, a different, non-public instance of itself). This is helpful for demonstrating a public microservice call to a non-public microservice, and then including the responses of both microservices in the payload delivered back to the user.  
+#### [Optional] Step 1 - Remove existing deployment 
 
-*NOTE:* this backend call assumes the downstream service is returning JSON.
+First, remove the default deployment, as the default deployment won't attempt to call the downstream service, since updating a configmap referenced by a pod will not automatically redeploy that pod:
 
-First, remove the default deployment, as the default deployment won't attempt to call the downstream service:
+```
+kubectl delete -k k8s
+```
 
-```kubectl delete -k k8s```
+#### [Optional] Step 2 - Deploy the backend instance
 
-Then, build the "backend" instance of `gke-whereami`:
-
-```kubectl apply -k k8s-backend-overlay-example```
+```
+kubectl apply -k k8s-backend-overlay-example
+```
 
 *or via [kustomize](https://kustomize.io/)*
 
-```kustomize build k8s-backend-overlay-example | kubectl apply -f -```
+```
+kustomize build k8s-backend-overlay-example | kubectl apply -f -
+```
 
-Once that service is up and running, modify `k8s/configmap.yaml`'s `BACKEND_ENABLED` to `"True"`.
+#### [Optional] Step 3 - Configure & deploy the frontend
+
+Modify `k8s/configmap.yaml`'s `BACKEND_ENABLED` field to `"True"`.
 
 Next, redeploy the "frontend" instance of `gke-whereami`:
 
-```kubectl apply -k k8s```
+```
+kubectl apply -k k8s
+```
 
 *or via [kustomize](https://kustomize.io/)*
 
-```kustomize build k8s | kubectl apply -f -```
-
-Get the service endpoint:
 ```
-WHEREAMI_ENDPOINT=$(kubectl get svc | grep -v EXTERNAL-IP | awk '{ print $4}')
+kustomize build k8s | kubectl apply -f -
 ```
 
 Get the service endpoint:
@@ -95,13 +107,13 @@ WHEREAMI_ENDPOINT=$(kubectl get svc | grep -v EXTERNAL-IP | awk '{ print $4}')
 
 Wrap things up by `curl`ing the `EXTERNAL-IP` of the service. 
 
-```curl $WHEREAMI_ENDPOINT```
+```
+curl $WHEREAMI_ENDPOINT
+```
 
 The (*slightly* busy-looking) result should look like this:
 
-```
-{"backend_result":{"cluster_name":"cluster-1","host_header":"whereami-backend","metadata":"backend","node_name":"gke-cluster-1-default-pool-c91b5644-v8kg.c.alexmattson-scratch.internal","pod_ip":"10.4.2.37","pod_name":"whereami-backend-86bdc7b596-z4dqk","pod_name_emoji":"💪🏾","pod_namespace":"default","pod_service_account":"whereami-ksa-backend","project_id":"alexmattson-scratch","timestamp":"2020-07-30T05:56:15","zone":"us-central1-c"},"cluster_name":"cluster-1","host_header":"34.72.90.134","metadata":"frontend","node_name":"gke-cluster-1-default-pool-c91b5644-1z7l.c.alexmattson-scratch.internal","pod_ip":"10.4.1.29","pod_name":"whereami-7888579d9d-qdmbg","pod_name_emoji":"🧜","pod_namespace":"default","pod_service_account":"whereami-ksa","project_id":"alexmattson-scratch","timestamp":"2020-07-30T05:56:15","zone":"us-central1-c"}
-```
+```{"backend_result":{"cluster_name":"cluster-1","host_header":"whereami-backend","metadata":"backend","node_name":"gke-cluster-1-default-pool-c91b5644-v8kg.c.alexmattson-scratch.internal","pod_ip":"10.4.2.37","pod_name":"whereami-backend-86bdc7b596-z4dqk","pod_name_emoji":"💪🏾","pod_namespace":"default","pod_service_account":"whereami-ksa-backend","project_id":"alexmattson-scratch","timestamp":"2020-07-30T05:56:15","zone":"us-central1-c"},"cluster_name":"cluster-1","host_header":"34.72.90.134","metadata":"frontend","node_name":"gke-cluster-1-default-pool-c91b5644-1z7l.c.alexmattson-scratch.internal","pod_ip":"10.4.1.29","pod_name":"whereami-7888579d9d-qdmbg","pod_name_emoji":"🧜","pod_namespace":"default","pod_service_account":"whereami-ksa","project_id":"alexmattson-scratch","timestamp":"2020-07-30T05:56:15","zone":"us-central1-c"}```
 
 Look at the `backend_result` field from the response. That portion of the JSON is from the backend service.
 
@@ -113,3 +125,4 @@ If you wish to call a different backend service, modify `k8s/configmap.yaml`'s `
 If you'd like to build & publish via Google's [buildpacks](https://github.com/GoogleCloudPlatform/buildpacks), something like this should do the trick (leveraging the local `Procfile`):
 
 ```pack build --builder gcr.io/buildpacks/builder:v1 --publish gcr.io/${PROJECT_ID}/whereami```
+

--- a/gke-whereami/README.md
+++ b/gke-whereami/README.md
@@ -6,7 +6,7 @@ This was originally written for testing & debugging multi-cluster ingress use ca
 
 ### Setup
 
-Create a GKE cluster 
+#### 1 - Create a GKE cluster 
 
 First define your environment variables (substituting where #needed#):
 
@@ -25,13 +25,13 @@ gcloud beta container clusters create $CLUSTER_NAME \
   --enable-ip-alias \
   --enable-stackdriver-kubernetes \
   --region=$COMPUTE_REGION \
-  --num-nodes=1 \
+  --num-nodes=2 \
   --release-channel=regular
 
 gcloud container clusters get-credentials $CLUSTER_NAME --region $COMPUTE_REGION
 ```
 
-Deploy the service/pods:
+#### 2 - Deploy the service/pods:
 
 ```kubectl apply -k k8s```
 
@@ -53,7 +53,7 @@ Result:
 ```{"cluster_name":"cluster-1","host_header":"34.72.90.134","metadata":"frontend","node_name":"gke-cluster-1-default-pool-c91b5644-v8kg.c.alexmattson-scratch.internal","pod_ip":"10.4.2.34","pod_name":"whereami-7b79956dd6-vmm9z","pod_name_emoji":"🧚🏼‍♀️","pod_namespace":"default","pod_service_account":"whereami-ksa","project_id":"alexmattson-scratch","timestamp":"2020-07-30T05:44:14","zone":"us-central1-c"}```
 
 
-#### using gke-whereami to call downstream services 
+#### 3 - [Optional] Use gke-whereami to call downstream services 
 
 `gke-whereami` has an optional flag within its configmap that will cause it to call another backend service within your GKE cluster (for example, a different, non-public instance of itself). This is helpful for demonstrating a public microservice call to a non-public microservice, and then including the responses of both microservices in the payload delivered back to the user.  
 
@@ -106,7 +106,7 @@ Look at the `backend_result` field from the response. That portion of the JSON i
 If you wish to call a different backend service, modify `k8s/configmap.yaml`'s `BACKEND_SERVICE` to some other service name. 
 
 
-#### Notes
+### Notes
 
 The operating port of the pod has been switched from `5000` to `8080` to work easily with the managed version of Cloud Run.
 

--- a/gke-whereami/README.md
+++ b/gke-whereami/README.md
@@ -46,8 +46,9 @@ kustomize build k8s | kubectl apply -f -
 ```
 
 Get the service endpoint:
+> Note: this may be `pending` for a few minutes while the service provisions
 ```
-WHEREAMI_ENDPOINT=$(kubectl get svc | grep -v EXTERNAL-IP | awk '{ print $4}')
+WHEREAMI_ENDPOINT=$(kubectl get svc whereami | grep -v EXTERNAL-IP | awk '{ print $4}')
 ```
 
 Wrap things up by `curl`ing the `EXTERNAL-IP` of the service. 
@@ -101,8 +102,9 @@ kustomize build k8s | kubectl apply -f -
 ```
 
 Get the service endpoint:
+> Note: this may be `pending` for a few minutes while the service provisions
 ```
-WHEREAMI_ENDPOINT=$(kubectl get svc | grep -v EXTERNAL-IP | awk '{ print $4}')
+WHEREAMI_ENDPOINT=$(kubectl get svc whereami | grep -v EXTERNAL-IP | awk '{ print $4}')
 ```
 
 Wrap things up by `curl`ing the `EXTERNAL-IP` of the service. 

--- a/gke-whereami/README.md
+++ b/gke-whereami/README.md
@@ -18,18 +18,20 @@ export COMPUTE_REGION=#YOUR_COMPUTE_REGION# # this expects a region, not a zone
 export CLUSTER_NAME=whereami
 ```
 
-Now create your resources:
+Now create your cluster:
 
 ```
 gcloud beta container clusters create $CLUSTER_NAME \
   --enable-ip-alias \
   --enable-stackdriver-kubernetes \
   --region=$COMPUTE_REGION \
-  --num-nodes=2 \
+  --num-nodes=1 \
   --release-channel=regular
 
 gcloud container clusters get-credentials $CLUSTER_NAME --region $COMPUTE_REGION
 ```
+
+This will create a regional cluster with a single node per zone (3 nodes in total). 
 
 #### Step 2 - Deploy the service/pods:
 
@@ -111,4 +113,3 @@ If you wish to call a different backend service, modify `k8s/configmap.yaml`'s `
 If you'd like to build & publish via Google's [buildpacks](https://github.com/GoogleCloudPlatform/buildpacks), something like this should do the trick (leveraging the local `Procfile`):
 
 ```pack build --builder gcr.io/buildpacks/builder:v1 --publish gcr.io/${PROJECT_ID}/whereami```
-

--- a/gke-whereami/README.md
+++ b/gke-whereami/README.md
@@ -6,7 +6,7 @@ This was originally written for testing & debugging multi-cluster ingress use ca
 
 ### Setup
 
-#### 1 - Create a GKE cluster 
+#### Step 1 - Create a GKE cluster 
 
 First define your environment variables (substituting where #needed#):
 
@@ -31,7 +31,7 @@ gcloud beta container clusters create $CLUSTER_NAME \
 gcloud container clusters get-credentials $CLUSTER_NAME --region $COMPUTE_REGION
 ```
 
-#### 2 - Deploy the service/pods:
+#### Step 2 - Deploy the service/pods:
 
 ```kubectl apply -k k8s```
 
@@ -53,7 +53,7 @@ Result:
 ```{"cluster_name":"cluster-1","host_header":"34.72.90.134","metadata":"frontend","node_name":"gke-cluster-1-default-pool-c91b5644-v8kg.c.alexmattson-scratch.internal","pod_ip":"10.4.2.34","pod_name":"whereami-7b79956dd6-vmm9z","pod_name_emoji":"🧚🏼‍♀️","pod_namespace":"default","pod_service_account":"whereami-ksa","project_id":"alexmattson-scratch","timestamp":"2020-07-30T05:44:14","zone":"us-central1-c"}```
 
 
-#### 3 - [Optional] Use gke-whereami to call downstream services 
+#### Step 3 - [Optional] Use gke-whereami to call downstream services 
 
 `gke-whereami` has an optional flag within its configmap that will cause it to call another backend service within your GKE cluster (for example, a different, non-public instance of itself). This is helpful for demonstrating a public microservice call to a non-public microservice, and then including the responses of both microservices in the payload delivered back to the user.  
 
@@ -107,8 +107,6 @@ If you wish to call a different backend service, modify `k8s/configmap.yaml`'s `
 
 
 ### Notes
-
-The operating port of the pod has been switched from `5000` to `8080` to work easily with the managed version of Cloud Run.
 
 If you'd like to build & publish via Google's [buildpacks](https://github.com/GoogleCloudPlatform/buildpacks), something like this should do the trick (leveraging the local `Procfile`):
 

--- a/gke-whereami/app.py
+++ b/gke-whereami/app.py
@@ -21,8 +21,14 @@ CORS(app)  # enable CORS
 emoji_list = list(emoji.unicode_codes.UNICODE_EMOJI.keys())
 
 
-@app.route('/')
-def home():
+@app.route('/healthz')  # healthcheck endpoint
+def i_am_healthy():
+    return ('OK')
+
+
+@app.route('/', defaults={'path': ''})
+@app.route('/<path:path>')
+def home(path):
 
     # define the response payload
     payload = {}
@@ -127,11 +133,6 @@ def home():
         payload['backend_result'] = backend_result
 
     return jsonify(payload)
-
-
-@app.route('/healthz')  # healthcheck endpoint
-def i_am_healthy():
-    return ('OK')
 
 
 if __name__ == '__main__':

--- a/gke-whereami/app.py
+++ b/gke-whereami/app.py
@@ -1,0 +1,150 @@
+import requests
+from flask import Flask, request, Response, jsonify
+import logging
+import json
+import sys
+import socket
+import os
+from datetime import datetime
+import emoji
+import random
+from flask_cors import CORS
+
+METADATA_URL = 'http://metadata.google.internal/computeMetadata/v1/'
+METADATA_HEADERS = {'Metadata-Flavor': 'Google'}
+
+app = Flask(__name__)
+app.config['JSON_AS_ASCII'] = False  # otherwise our emojis get hosed
+CORS(app)  # enable CORS
+
+# set up emoji list
+emoji_list = list(emoji.unicode_codes.UNICODE_EMOJI.keys())
+
+
+@app.route('/')
+def home():
+
+    # get project ID
+    try:
+        r = requests.get(METADATA_URL +
+                         'project/project-id',
+                         headers=METADATA_HEADERS)
+        if r.ok:
+            project_id = r.text
+        else:
+            project_id = None
+    except:
+
+        project_id = None
+
+    # get zone
+    try:
+        r = requests.get(METADATA_URL +
+                         'instance/zone',
+                         headers=METADATA_HEADERS)
+        if r.ok:
+            zone = str(r.text.split("/")[3])
+        else:
+            zone = None
+    except:
+
+        zone = None
+
+    # get gke node_name
+    try:
+        r = requests.get(METADATA_URL +
+                         'instance/hostname',
+                         headers=METADATA_HEADERS)
+        if r.ok:
+            node_name = str(r.text)
+        else:
+            node_name = None
+    except:
+
+        node_name = None
+
+    # get cluster
+    try:
+        r = requests.get(METADATA_URL +
+                         'instance/attributes/cluster-name',
+                         headers=METADATA_HEADERS)
+        if r.ok:
+            cluster_name = str(r.text)
+        else:
+            cluster_name = None
+    except:
+
+        cluster_name = None
+
+    # get host header
+    try:
+        host_header = request.headers.get('host')
+    except:
+        host_header = None
+
+    # get pod name
+    pod_name = socket.gethostname()
+
+    # get datetime
+    timestamp = datetime.now().replace(microsecond=0).isoformat()
+
+    # get k8s namespace, pod ip, and pod service account
+    pod_namespace = os.getenv('POD_NAMESPACE')
+    pod_ip = os.getenv('POD_IP')
+    pod_service_account = os.getenv('POD_SERVICE_ACCOUNT')
+
+    # get the whereami ID_STRING envvar
+    id_string = os.getenv('ID_STRING')
+
+    payload = {}
+    payload['cluster_name'] = cluster_name
+    payload['host_header'] = host_header
+    payload['node_name'] = node_name
+    payload['pod_ip'] = pod_ip
+    payload['pod_name'] = pod_name
+    payload['pod_name_emoji'] = emoji_list[hash(pod_name) % len(emoji_list)]
+    payload['pod_namespace'] = pod_namespace
+    payload['pod_service_account'] = pod_service_account
+    payload['project_id'] = project_id
+    payload['timestamp'] = timestamp
+    payload['id_string'] = id_string
+    payload['zone'] = zone
+
+    # should we call a backend service?
+    call_backend = os.getenv('BACKEND_ENABLED')
+
+    if call_backend == 'True':
+
+        backend_service = os.getenv('BACKEND_SERVICE')
+
+        try:
+            r = requests.get('http://' + backend_service)
+            if r.ok:
+                backend_result = r.json()
+            else:
+                backend_result = None
+        except:
+
+            print(sys.exc_info()[0])
+            backend_result = None
+
+        payload['backend_result'] = backend_result
+
+    return jsonify(payload)
+
+
+@app.route('/healthz')
+def i_am_healthy():
+    return ('OK')
+
+
+if __name__ == '__main__':
+    out_hdlr = logging.StreamHandler(sys.stdout)
+    fmt = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    out_hdlr.setFormatter(fmt)
+    out_hdlr.setLevel(logging.INFO)
+    logging.getLogger().addHandler(out_hdlr)
+    logging.getLogger().setLevel(logging.INFO)
+    app.logger.handlers = []
+    app.logger.propagate = True
+    app.run(host='0.0.0.0', port=int(os.environ.get('PORT', 8080)))

--- a/gke-whereami/k8s-backend-overlay-example/cm-flag.yaml
+++ b/gke-whereami/k8s-backend-overlay-example/cm-flag.yaml
@@ -4,4 +4,4 @@ metadata:
   name: whereami-configmap
 data:
   BACKEND_ENABLED: "False" # assuming you don't want a chain of backend calls
-  ID_STRING:       "backend"
+  METADATA:        "backend"

--- a/gke-whereami/k8s-backend-overlay-example/cm-flag.yaml
+++ b/gke-whereami/k8s-backend-overlay-example/cm-flag.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: whereami-configmap
+data:
+  BACKEND_ENABLED: "False" # assuming you don't want a chain of backend calls
+  ID_STRING:       "backend"

--- a/gke-whereami/k8s-backend-overlay-example/kustomization.yaml
+++ b/gke-whereami/k8s-backend-overlay-example/kustomization.yaml
@@ -1,0 +1,8 @@
+nameSuffix: "-backend"
+commonLabels:
+  app: whereami-backend
+bases:
+- ../k8s
+patches:
+- cm-flag.yaml
+- service-type.yaml

--- a/gke-whereami/k8s-backend-overlay-example/service-type.yaml
+++ b/gke-whereami/k8s-backend-overlay-example/service-type.yaml
@@ -1,0 +1,6 @@
+apiVersion: "v1"
+kind: "Service"
+metadata:
+  name: "whereami"
+spec:
+  type: ClusterIP

--- a/gke-whereami/k8s/configmap.yaml
+++ b/gke-whereami/k8s/configmap.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: whereami-configmap
+data:
+  BACKEND_ENABLED: "False" # flag to enable backend service call "False" || "True"
+  BACKEND_SERVICE: "whereami-backend" # substitute with corresponding service name - this example assumes both services are in the same namespace  
+  ID_STRING:       "frontend" # arbitrary string that gets returned in payload - can be used to track which services you're interacting with 

--- a/gke-whereami/k8s/configmap.yaml
+++ b/gke-whereami/k8s/configmap.yaml
@@ -5,4 +5,4 @@ metadata:
 data:
   BACKEND_ENABLED: "False" # flag to enable backend service call "False" || "True"
   BACKEND_SERVICE: "whereami-backend" # substitute with corresponding service name - this example assumes both services are in the same namespace  
-  ID_STRING:       "frontend" # arbitrary string that gets returned in payload - can be used to track which services you're interacting with 
+  METADATA:        "frontend" # arbitrary string that gets returned in payload - can be used to track which services you're interacting with 

--- a/gke-whereami/k8s/deployment.yaml
+++ b/gke-whereami/k8s/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: whereami-ksa
       containers:
       - name: whereami
-        image: gcr.io/alexmattson-scratch/whereami@sha256:b592d113dff6ca1584d8f8d5a3aa2aca437e1764b2c86db061d9a7eaa3e81815
+        image: gcr.io/alexmattson-scratch/whereami@sha256:1afaf0c7710c38a688529c3767895e86194e6c4bfb1c97c150e30532d31da526
         ports:
           - name: http
             containerPort: 8080
@@ -58,8 +58,8 @@ spec:
               configMapKeyRef:
                 name: whereami-configmap
                 key: BACKEND_SERVICE
-          - name: ID_STRING
+          - name: METADATA
             valueFrom:
               configMapKeyRef:
                 name: whereami-configmap
-                key: ID_STRING
+                key: METADATA

--- a/gke-whereami/k8s/deployment.yaml
+++ b/gke-whereami/k8s/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: whereami-ksa
       containers:
       - name: whereami
-        image: gcr.io/alexmattson-scratch/whereami@sha256:53ce7faf4ac8245d5b127da36d74fea7be73100306c553cfaebbc58e057224df
+        image: gcr.io/alexmattson-scratch/whereami:v1.0
         ports:
           - name: http
             containerPort: 8080

--- a/gke-whereami/k8s/deployment.yaml
+++ b/gke-whereami/k8s/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: whereami
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: whereami
+  template:
+    metadata:
+      labels:
+        app: whereami
+        version: v1
+    spec:
+      serviceAccountName: whereami-ksa
+      containers:
+      - name: whereami
+        image: gcr.io/alexmattson-scratch/whereami@sha256:b592d113dff6ca1584d8f8d5a3aa2aca437e1764b2c86db061d9a7eaa3e81815
+        ports:
+          - name: http
+            containerPort: 8080
+        livenessProbe:
+          httpGet:
+              path: /healthz
+              port: 8080
+              scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 15
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+        env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: POD_SERVICE_ACCOUNT
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.serviceAccountName
+          - name: BACKEND_ENABLED
+            valueFrom:
+              configMapKeyRef:
+                name: whereami-configmap
+                key: BACKEND_ENABLED
+          - name: BACKEND_SERVICE
+            valueFrom:
+              configMapKeyRef:
+                name: whereami-configmap
+                key: BACKEND_SERVICE
+          - name: ID_STRING
+            valueFrom:
+              configMapKeyRef:
+                name: whereami-configmap
+                key: ID_STRING

--- a/gke-whereami/k8s/deployment.yaml
+++ b/gke-whereami/k8s/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: whereami-ksa
       containers:
       - name: whereami
-        image: gcr.io/alexmattson-scratch/whereami@sha256:1afaf0c7710c38a688529c3767895e86194e6c4bfb1c97c150e30532d31da526
+        image: gcr.io/alexmattson-scratch/whereami@sha256:138748565fa955bea5cd5d7497ab8b527090fedb702f6b1fc0ea075105800c24
         ports:
           - name: http
             containerPort: 8080

--- a/gke-whereami/k8s/deployment.yaml
+++ b/gke-whereami/k8s/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: whereami-ksa
       containers:
       - name: whereami
-        image: gcr.io/alexmattson-scratch/whereami@sha256:138748565fa955bea5cd5d7497ab8b527090fedb702f6b1fc0ea075105800c24
+        image: gcr.io/alexmattson-scratch/whereami@sha256:53ce7faf4ac8245d5b127da36d74fea7be73100306c553cfaebbc58e057224df
         ports:
           - name: http
             containerPort: 8080

--- a/gke-whereami/k8s/ksa.yaml
+++ b/gke-whereami/k8s/ksa.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: whereami-ksa

--- a/gke-whereami/k8s/kustomization.yaml
+++ b/gke-whereami/k8s/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+- ksa.yaml
+- deployment.yaml
+- service.yaml
+- configmap.yaml

--- a/gke-whereami/k8s/service.yaml
+++ b/gke-whereami/k8s/service.yaml
@@ -2,7 +2,6 @@
   kind: "Service"
   metadata:
     name: "whereami"
-    #namespace: "whereami"
   spec:
     ports:
     - port: 80

--- a/gke-whereami/k8s/service.yaml
+++ b/gke-whereami/k8s/service.yaml
@@ -1,0 +1,13 @@
+  apiVersion: "v1"
+  kind: "Service"
+  metadata:
+    name: "whereami"
+    #namespace: "whereami"
+  spec:
+    ports:
+    - port: 80
+      targetPort: 8080
+      name: http # adding for Istio
+    selector:
+      app: "whereami"
+    type: "LoadBalancer"

--- a/gke-whereami/requirements.txt
+++ b/gke-whereami/requirements.txt
@@ -1,0 +1,4 @@
+flask
+requests
+emoji
+flask-cors


### PR DESCRIPTION
Per internal discussion, adding `gke-whereami` to GKE samples to enable public-facing multicluster demos 