### PR TITLE
Update apiVersion of deployment manifest

### DIFF
--- a/quickstart/deployment.yaml
+++ b/quickstart/deployment.yaml
@@ -1,5 +1,5 @@
 # This file configures the hello-world app which serves public web traffic.
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: helloworld-gke


### PR DESCRIPTION
Using the quickstart[1] with this manifest results in an error of ` error: unable to recognize "deployment.yaml": no matches for kind "Deployment" in version "extensions/v1beta1"`

Updating the apiVersion to apps/v1 resolves this error.

[1] https://cloud.google.com/kubernetes-engine/docs/quickstarts/deploying-a-language-specific-app#deploy_an_app