### PR TITLE
Create a new Deployment manifest

### DIFF
--- a/migrating-node-pool/README.md
+++ b/migrating-node-pool/README.md
@@ -4,5 +4,5 @@ This example shows how to migrate workloads running on
 [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine)
 without incurring downtime.
 
-Visit https://cloud.google.com/solutions/continuous-delivery-spinnaker-kubernetes-engine
+Visit https://cloud.google.com/kubernetes-engine/docs/tutorials/migrating-node-pool
 to follow the tutorial.

--- a/migrating-node-pool/README.md
+++ b/migrating-node-pool/README.md
@@ -1,0 +1,8 @@
+# Migrating node pools example
+
+This example shows how to migrate workloads running on
+[Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine)
+without incurring downtime.
+
+Visit https://cloud.google.com/solutions/continuous-delivery-spinnaker-kubernetes-engine
+to follow the tutorial.

--- a/migrating-node-pool/node-pools-deployment.yaml
+++ b/migrating-node-pool/node-pools-deployment.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 6
+  selector:
+    matchLabels:
+      app: hello-app
+  template:
+    metadata:
+      labels:
+        app: hello-app
+    spec:
+      containers:
+      - name: hello-app
+        image: gcr.io/google-samples/hello-app:1.0


### PR DESCRIPTION
The GKE Tutorial Migrating Node Pool[1] includes a step that no longer works, as kubectl run for Deployments was deprecated. This file is intended to replace that command in the guide. Once this is merged, the tutorial will be updated soon after to use this manifest instead of the old command.

Please let me know if you would like me to create a README.md file in this folder, such as the one [here](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/master/wordpress-persistent-disks/README.md) I believe this is the first file for this tutorial in the samples repo. 

[1] https://cloud.google.com/kubernetes-engine/docs/tutorials/migrating-node-pool