### PR TITLE
Network policy tutorial manifests

### DIFF
--- a/network-policies/README.md
+++ b/network-policies/README.md
@@ -1,0 +1,7 @@
+# Configuring network policies example
+
+This example shows how to use cluster [network policies](https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy)
+to control network traffic for Pods.
+
+Visit https://cloud.google.com/kubernetes-engine/docs/tutorials/network-policy
+to follow the tutorial.

--- a/network-policies/foo-allow-to-hello.yaml
+++ b/network-policies/foo-allow-to-hello.yaml
@@ -1,0 +1,20 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: foo-allow-to-hello
+spec:
+  policyTypes:
+  - Egress
+  podSelector:
+    matchLabels:
+      app: foo
+  egress:
+  - to:
+    - podSelector:
+        matchLabels:
+          app: hello
+  - ports:
+    - port: 53
+      protocol: TCP
+    - port: 53
+      protocol: UDP

--- a/network-policies/hello-allow-from-foo.yaml
+++ b/network-policies/hello-allow-from-foo.yaml
@@ -1,0 +1,15 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: hello-allow-from-foo
+spec:
+  policyTypes:
+  - Ingress
+  podSelector:
+    matchLabels:
+      app: hello
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: foo


### PR DESCRIPTION
This PR is to create copies of the manifests in the GKE tutorial Configuring Network Policies for Applications[1] into GitHub. Once this is merged, the tutorial will be updated to point to these files in GitHub, matching the other GKE tutorials.

Please let me know if you would like me to change the names of the files or the folder, I matched the names from the tutorial.

[1] https://cloud.google.com/kubernetes-engine/docs/tutorials/network-policy