### PR TITLE
Adding Ingress Manifests

### DIFF
--- a/load-balancing/README.md
+++ b/load-balancing/README.md
@@ -4,5 +4,4 @@ This example shows how to run a web application behind
 an [external HTTP(S) load balancer](https://cloud.google.com/load-balancing/docs/https)
 using the [Ingress](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress) resource.
 
-Visit https://cloud.google.com/kubernetes-engine/docs/concepts/ingress
-to follow the tutorial.
+Visit https://cloud.google.com/kubernetes-engine/docs/tutorials/http-balancer to follow the tutorial.

--- a/load-balancing/README.md
+++ b/load-balancing/README.md
@@ -5,3 +5,9 @@ an [external HTTP(S) load balancer](https://cloud.google.com/load-balancing/docs
 using the [Ingress](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress) resource.
 
 Visit https://cloud.google.com/kubernetes-engine/docs/tutorials/http-balancer to follow the tutorial.
+
+This directory contains:
+
+- `basic-ingress.yaml` defines an Ingress resource
+- `basic-ingress-static.yaml` defines an Ingress resource that uses a reserved IP address
+- `fanout-ingress.yaml` defines an Ingress resource that routes requests to different Services by path

--- a/load-balancing/README.md
+++ b/load-balancing/README.md
@@ -11,3 +11,7 @@ This directory contains:
 - `basic-ingress.yaml` defines an Ingress resource.
 - `basic-ingress-static.yaml` defines an Ingress resource that uses a reserved IP address.
 - `fanout-ingress.yaml` defines an Ingress resource that routes requests to different Services by path.
+- `web-deployment.yaml` defines a Deployment resource.
+- `web-deployment-v2.yaml` defines a second Deployment resource.
+- `web-service.yaml` defines a Service resource that makes the deployment reachable within your cluster.
+- `web-service-v2.yaml` defines a second Service resource.

--- a/load-balancing/README.md
+++ b/load-balancing/README.md
@@ -8,6 +8,6 @@ Visit https://cloud.google.com/kubernetes-engine/docs/tutorials/http-balancer to
 
 This directory contains:
 
-- `basic-ingress.yaml` defines an Ingress resource
-- `basic-ingress-static.yaml` defines an Ingress resource that uses a reserved IP address
-- `fanout-ingress.yaml` defines an Ingress resource that routes requests to different Services by path
+- `basic-ingress.yaml` defines an Ingress resource.
+- `basic-ingress-static.yaml` defines an Ingress resource that uses a reserved IP address.
+- `fanout-ingress.yaml` defines an Ingress resource that routes requests to different Services by path.

--- a/load-balancing/README.md
+++ b/load-balancing/README.md
@@ -1,0 +1,8 @@
+# Setting up HTTP(S) Load Balancing with Ingress example
+
+This example shows how to run a web application behind
+an [external HTTP(S) load balancer](https://cloud.google.com/load-balancing/docs/https)
+using the [Ingress](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress) resource.
+
+Visit https://cloud.google.com/kubernetes-engine/docs/concepts/ingress
+to follow the tutorial.

--- a/load-balancing/basic-ingress-static.yaml
+++ b/load-balancing/basic-ingress-static.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: basic-ingress
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: "web-static-ip"
+spec:
+  backend:
+    serviceName: web
+    servicePort: 8080

--- a/load-balancing/basic-ingress.yaml
+++ b/load-balancing/basic-ingress.yaml
@@ -1,0 +1,8 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: basic-ingress
+spec:
+  backend:
+    serviceName: web
+    servicePort: 8080

--- a/load-balancing/fanout-ingress.yaml
+++ b/load-balancing/fanout-ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: fanout-ingress
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /*
+        backend:
+          serviceName: web
+          servicePort: 8080
+      - path: /v2/*
+        backend:
+          serviceName: web2
+          servicePort: 8080

--- a/load-balancing/web-deployment-v2.yaml
+++ b/load-balancing/web-deployment-v2.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web2
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      run: web2
+  template:
+    metadata:
+      labels:
+        run: web2
+    spec:
+      containers:
+      - image: gcr.io/google-samples/hello-app:2.0
+        imagePullPolicy: IfNotPresent
+        name: web2
+        ports:
+        - containerPort: 8080
+          protocol: TCP

--- a/load-balancing/web-deployment.yaml
+++ b/load-balancing/web-deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      run: web
+  template:
+    metadata:
+      labels:
+        run: web
+    spec:
+      containers:
+      - image: gcr.io/google-samples/hello-app:1.0
+        imagePullPolicy: IfNotPresent
+        name: web
+        ports:
+        - containerPort: 8080
+          protocol: TCP

--- a/load-balancing/web-service-v2.yaml
+++ b/load-balancing/web-service-v2.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web2
+  namespace: default
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    run: web2
+  type: NodePort

--- a/load-balancing/web-service.yaml
+++ b/load-balancing/web-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+  namespace: default
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    run: web
+  type: NodePort


### PR DESCRIPTION
This PR is to create copies of the manifests in the GKE tutorial "Setting up HTTP(S) Load Balancing with Ingress"[1] into GitHub. 

Note that the current tutorial instructs the user to replace the `basic-ingree.yaml` manifest file with the content of a new file. My suggestion is to split that into two files, and change the tutorial to specify to use the new manifest instead of copying it[2]. Alternatively, I could omit importing the file as it currently uses line-highlighting on the annotation that is likely not possible to do when pulling the file from github.

If you agree with this suggestion, I can update the tutorial after this PR is merged.

Prior to merging, I will squash the commits into a single, descriptive commit.

[1] https://cloud.google.com/kubernetes-engine/docs/tutorials/http-balancer
[2] https://cloud.google.com/kubernetes-engine/docs/tutorials/http-balancer#step_5_optional_configure_a_static_ip_address