### PR TITLE
updated w/ hack to address thread starvation issue w/ gRPC serving

### DIFF
--- a/whereami/app.py
+++ b/whereami/app.py
@@ -38,8 +38,10 @@ class WhereamigRPC(whereami_pb2_grpc.WhereamiServicer):
 # see https://github.com/grpc/grpc/blob/master/examples/python/xds/server.py
 # for reference on code below
 def grpc_serve():
+    # the +5 you see below re: max_workers is a hack to avoid thread starvation
+    # working on a proper workaround
     server = grpc.server(
-        futures.ThreadPoolExecutor(max_workers=multiprocessing.cpu_count()))
+        futures.ThreadPoolExecutor(max_workers=multiprocessing.cpu_count()+5))
 
     # Add the application servicer to the server.
     whereami_pb2_grpc.add_WhereamiServicer_to_server(WhereamigRPC(), server)

--- a/whereami/k8s-grpc/deployment.yaml
+++ b/whereami/k8s-grpc/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: whereami-grpc-ksa
       containers:
       - name: whereami-grpc
-        image: gcr.io/google-samples/whereami:v1.1.1
+        image: gcr.io/google-samples/whereami:v1.1.2
         ports:
           - name: grpc
             containerPort: 9090

--- a/whereami/k8s/deployment.yaml
+++ b/whereami/k8s/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: whereami-ksa
       containers:
       - name: whereami
-        image: gcr.io/google-samples/whereami:v1.1.1
+        image: gcr.io/google-samples/whereami:v1.1.2
         ports:
           - name: http
             containerPort: 8080


### PR DESCRIPTION
received this from a SWE on the gRPC / Python team: 

```
I was able to reproduce the issue as you've described. Since reflection calls seemed to hang while doing a GetPayload request, I suspected this was a thread starvation issue (which is odd, since you've used the nonblocking health check API). I also found that my manual health check attempts 
hung. All of this behavior continued even when I took xDS out of the picture.

The server container only has a single core, so your application threadpool was instantiated with only a single thread. By bumping up the number of threads in the application threadpool, I was able to make things work as expected. But this begs the question "who is hogging your threads?" You've got two threadpools of size 1 each, which would imply that someone has an initiated a hung RPC on each of those. I can't explain that yet. Still investigating.

In the meantime, however, you can continue making progress on your side by instantiating your threadpool with futures.ThreadPoolExecutor(max_workers=multiprocessing.cpu_count() + 5)). This is a completely arbitrary number and not ideal for long-term use, though.
```

Added the `+5` for now to the `whereami` code to get things working for gRPC use cases. Also pushed a new container image (referenced in `deployment.yaml`s) based on the updates.