### PR TITLE
Bump gke-windows-builder version to 2.0.0

### DIFF
--- a/windows-multi-arch/Dockerfile
+++ b/windows-multi-arch/Dockerfile
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 # [START container_windows_multi_arch_dockerfile]
-ARG version=
-FROM mcr.microsoft.com/windows/servercore:${version}
+ARG WINDOWS_VERSION=
+FROM mcr.microsoft.com/windows/servercore:${WINDOWS_VERSION}
 COPY hello.exe /hello.exe
 USER ContainerUser
 ENTRYPOINT ["hello.exe"]

--- a/windows-multi-arch/cloudbuild.yaml
+++ b/windows-multi-arch/cloudbuild.yaml
@@ -15,7 +15,7 @@
 # [START container_windows_multi_arch_cloudbuild]
 timeout: 3600s
 steps:
-- name: 'gcr.io/gke-release/gke-windows-builder:release-1.0.0-gke.0'
+- name: 'gcr.io/gke-release/gke-windows-builder:release-2.0.0-gke.0'
   args:
   - --container-image-name
   - 'gcr.io/$PROJECT_ID/multiarch-helloworld:latest'


### PR DESCRIPTION
Increases the [gke-windows-builder](http://gcr.io/gke-release/gke-windows-builder) version to the latest release we've pushed, 2.0.0, and updated the example Dockerfile to match its adjusted arguments.