### PR TITLE
Upgrade autoscaling API from v2beta1 to v2beta2

### DIFF
--- a/cloud-pubsub/deployment/pubsub-hpa.yaml
+++ b/cloud-pubsub/deployment/pubsub-hpa.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # [START container_pubsub_horizontal_pod_autoscaler]
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: pubsub
@@ -22,14 +22,17 @@ spec:
   maxReplicas: 5
   metrics:
   - external:
-      metricName: pubsub.googleapis.com|subscription|num_undelivered_messages
-      metricSelector:
-        matchLabels:
-          resource.labels.subscription_id: echo-read
-      targetAverageValue: "2"
+      metric:
+       name: pubsub.googleapis.com|subscription|num_undelivered_messages
+       selector:
+         matchLabels:
+           resource.labels.subscription_id: echo-read
+      target:
+        type: AverageValue
+        averageValue: 2
     type: External
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
     name: pubsub
-# [END container_pubsub_horizontal_pod_autoscaler]
+# [START container_pubsub_horizontal_pod_autoscaler]

--- a/cloud-pubsub/deployment/pubsub-hpa.yaml
+++ b/cloud-pubsub/deployment/pubsub-hpa.yaml
@@ -35,4 +35,4 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: pubsub
-# [START container_pubsub_horizontal_pod_autoscaler]
+# [END container_pubsub_horizontal_pod_autoscaler]

--- a/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd-hpa.yaml
+++ b/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd-hpa.yaml
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 # [START container_custom_metrics_direct_horizontal_pod_autoscaler]
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: custom-metric-sd
   namespace: default
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: custom-metric-sd
   minReplicas: 1
@@ -28,6 +28,9 @@ spec:
   metrics:
   - type: Pods
     pods:
-      metricName: custom-metric
-      targetAverageValue: 20
+      metric:
+        name: custom-metric
+      target:
+        type: AverageValue
+        averageValue: 20
 # [END container_custom_metrics_direct_horizontal_pod_autoscaler]

--- a/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd-hpa.yaml
+++ b/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd-hpa.yaml
@@ -13,14 +13,32 @@
 # limitations under the License.
 
 # [START container_custom_metrics_prometheus_horizontal_pod_autoscaler]
-apiVersion: autoscaling/v2beta1
+# apiVersion: autoscaling/v2beta1
+# kind: HorizontalPodAutoscaler
+# metadata:
+#   name: custom-prometheus-hpa
+#   namespace: default
+# spec:
+#   scaleTargetRef:
+#     apiVersion: apps/v1beta1
+#     kind: Deployment
+#     name: custom-metric-prometheus-sd
+#   minReplicas: 1
+#   maxReplicas: 5
+#   metrics:
+#   - type: Pods
+#     pods:
+#       metricName: custom_prometheus
+#       targetAverageValue: 20
+# [END container_custom_metrics_prometheus_horizontal_pod_autoscaler]
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: custom-prometheus-hpa
+  name: custom-prometheus-sd
   namespace: default
 spec:
   scaleTargetRef:
-    apiVersion: apps/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: custom-metric-prometheus-sd
   minReplicas: 1
@@ -28,6 +46,8 @@ spec:
   metrics:
   - type: Pods
     pods:
-      metricName: custom_prometheus
-      targetAverageValue: 20
-# [END container_custom_metrics_prometheus_horizontal_pod_autoscaler]
+      metric:
+        name: custom_prometheus
+      target:
+        type: AverageValue
+        averageValue: 20

--- a/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd-hpa.yaml
+++ b/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd-hpa.yaml
@@ -16,7 +16,7 @@
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: custom-prometheus-sd
+  name: custom-prometheus-hpa
   namespace: default
 spec:
   scaleTargetRef:

--- a/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd-hpa.yaml
+++ b/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd-hpa.yaml
@@ -13,24 +13,6 @@
 # limitations under the License.
 
 # [START container_custom_metrics_prometheus_horizontal_pod_autoscaler]
-# apiVersion: autoscaling/v2beta1
-# kind: HorizontalPodAutoscaler
-# metadata:
-#   name: custom-prometheus-hpa
-#   namespace: default
-# spec:
-#   scaleTargetRef:
-#     apiVersion: apps/v1beta1
-#     kind: Deployment
-#     name: custom-metric-prometheus-sd
-#   minReplicas: 1
-#   maxReplicas: 5
-#   metrics:
-#   - type: Pods
-#     pods:
-#       metricName: custom_prometheus
-#       targetAverageValue: 20
-# [END container_custom_metrics_prometheus_horizontal_pod_autoscaler]
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -51,3 +33,4 @@ spec:
       target:
         type: AverageValue
         averageValue: 20
+# [END container_custom_metrics_prometheus_horizontal_pod_autoscaler]

--- a/hello-app/manifests/helloweb-deployment.yaml
+++ b/hello-app/manifests/helloweb-deployment.yaml
@@ -35,4 +35,7 @@ spec:
         image: gcr.io/google-samples/hello-app:1.0
         ports:
         - containerPort: 8080
+        resources:
+          requests:
+            cpu: 200m
 # [END container_helloapp_deployment]

--- a/hello-app/manifests/helloweb-hpa.yaml
+++ b/hello-app/manifests/helloweb-hpa.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,20 +13,22 @@
 # limitations under the License.
 
 # [START container_helloapp_horizontal_pod_autoscaler]
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: cpu
 spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: helloweb
   minReplicas: 1
   maxReplicas: 5
   metrics:
   - type: Resource
     resource:
       name: cpu
-      targetAverageUtilization: 30
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: helloweb
+      target:
+        type: Utilization
+        averageUtilization: 30
 # [END container_helloapp_horizontal_pod_autoscaler]


### PR DESCRIPTION
Upgrades autoscaling API from `v2beta1` to `v2beta2` for the following reasons: 

1. the GKE default version (1.17) now supports the following autoscaling APIs--

``` 
autoscaling/v1
autoscaling/v2beta1
autoscaling/v2beta2
```

2. `autoscaling/v2beta1` [was deprecated in K8s 1.19](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md#deprecation), so will soon be the case for the default GKE version as well. 

3. The [GKE HPA how-to doc](https://cloud.google.com/kubernetes-engine/docs/how-to/horizontal-pod-autoscaling?hl=en ) now uses`v2beta2`


### changelog 

[Updates all 4 HPAs](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/search?q=HorizontalPodAutoscaler) in the GKE samples (helloapp, pubsub, custom metric, prometheus metric) from `autoscaling/v2beta1` to `autoscaling/v2beta2`. All logic left intact, syntax changes required for the new API. Only extra file that needed an update was the hello app deployment -- looks like you need to explicitly set `cpu` requests before setting an HPA on it. 


### how to test 

Navigate to this tutorial: https://cloud.google.com/kubernetes-engine/docs/tutorials/autoscaling-metrics 

Go through all 4 paths (tabs) in the tutorial -- **except when** asked to clone this repo, instead of the master branch, use the `hpa-v2beta2` branch. You should be able to successfully see pods scale up in all 4 cases, this means the HPA is working. For debugging, use `kubectl describe hpa`. 