### PR TITLE
and per-field URLs for payload to whereami

### DIFF
--- a/whereami/README.md
+++ b/whereami/README.md
@@ -193,6 +193,17 @@ $ curl $ENDPOINT
 }
 ```
 
+The JSON payload example above covers the majority of fields that `whereami` can return. In the following sections, you will see how it's possible to have `whereami` to call downstream services, adding additional data to that payload. Before you do that, it's worth pointing out that `whereami` can also return individual fields from that JSON payload as plaintext, so long as you include the field's name as a suffix to the path you're calling. Let's see an example.
+
+Suppose you only care about the `pod_name_emoji` value. You can do the following to capture only that value in the response:
+
+```bash
+$ curl $ENDPOINT/path12345/pod_name_emoji
+
+🧚🏽
+```
+
+`whereami` will evaluate the path you're accessing, and as long as the last part of the path matches a valid field name of the JSON response, it will return that value. Otherwise, you'll get the full JSON response.
 
 
 ### Setup a backend service call

--- a/whereami/README.md
+++ b/whereami/README.md
@@ -11,7 +11,7 @@
 `whereami` is a single-container app, designed and packaged to run on Kubernetes. In it's simplest form it can be deployed in a single line with only a few parameters.
 
 ```bash
-$ kubectl run --image=gcr.io/google-samples/whereami:v1.1.3 --expose --port 8080 whereami
+$ kubectl run --image=gcr.io/google-samples/whereami:v1.1.4 --expose --port 8080 whereami
 ```
 
 The `whereami`  pod listens on port `8080` and returns a very simple JSON response that indicates who is responding and where they live. This example assumes you're executing the `curl` command from a pod in the same K8s cluster & namespace (although the following examples show how to access from external clients):
@@ -96,7 +96,7 @@ spec:
       serviceAccountName: whereami-ksa
       containers:
       - name: whereami
-        image: gcr.io/google-samples/whereami:v1.1.3
+        image: gcr.io/google-samples/whereami:v1.1.4
         ports:
           - name: http
             containerPort: 8080 #The application is listening on port 8080

--- a/whereami/README.md
+++ b/whereami/README.md
@@ -198,7 +198,7 @@ The JSON payload example above covers the majority of fields that `whereami` can
 Suppose you only care about the `pod_name_emoji` value. You can do the following to capture only that value in the response:
 
 ```bash
-$ curl $ENDPOINT/path12345/pod_name_emoji
+$ curl $ENDPOINT/some/path/prefix/pod_name_emoji
 
 🧚🏽
 ```

--- a/whereami/README.md
+++ b/whereami/README.md
@@ -203,7 +203,14 @@ $ curl $ENDPOINT/path12345/pod_name_emoji
 🧚🏽
 ```
 
-`whereami` will evaluate the path you're accessing, and as long as the last part of the path matches a valid field name of the JSON response, it will return that value. Otherwise, you'll get the full JSON response.
+`whereami` will evaluate the path you're accessing, and as long as the last part of the path matches a valid field name of the JSON response, it will return that value. Otherwise, you'll get the full JSON response. 
+
+The fields/path suffixes that are *always* available in a HTTP `whereami` response are:
+
+- `host_header`
+- `pod_name`
+- `pod_name_emoji`
+- `timestamp`
 
 
 ### Setup a backend service call
@@ -378,7 +385,7 @@ By setting the feature flag `GRPC_ENABLED` in the `whereami` configmap (see [her
 
 If gRPC is enabled for a given pod, that `whereami` pod will not respond to HTTP requests, and any downstream service calls that the pod makes will also use gRPC only.
 
-> Note: because gRPC is used as the protocol, the `whereami-grpc` response will omit any `header` fields *and* listens on port `9090` instead of port `8080`.
+> Note: because gRPC is used as the protocol, the `whereami-grpc` response will omit any `header` fields *and* listens on port `9090` instead of port `8080`. 
 
 #### Step 1 - Deploy the whereami-grpc backend
 

--- a/whereami/README.md
+++ b/whereami/README.md
@@ -381,7 +381,7 @@ $ curl $ENDPOINT -s | jq .
 
 All of the prior examples for `whereami` are based on its default operating mode of using [Flask](https://flask.palletsprojects.com/en/1.1.x/) as its server. The following section details how `whereami` can be configured to use [gRPC](https://grpc.io/) instead.
 
-By setting the feature flag `GRPC_ENABLED` in the `whereami` configmap (see [here](k8s-grpc/configmap.yaml) to `"True"`, `whereami` can be interacted with using [gRPC](https://grpc.io/), with support for the gRPC [health check protocol](https://github.com/grpc/grpc/blob/master/doc/health-checking.md). The examples below leverage [grpcurl](https://github.com/fullstorydev/grpcurl), and assume you've already deployed a GKE cluster.
+By setting the feature flag `GRPC_ENABLED` in the `whereami` configmap (see [here](k8s-grpc/configmap.yaml)) to `"True"`, `whereami` can be interacted with using [gRPC](https://grpc.io/), with support for the gRPC [health check protocol](https://github.com/grpc/grpc/blob/master/doc/health-checking.md). The examples below leverage [grpcurl](https://github.com/fullstorydev/grpcurl), and assume you've already deployed a GKE cluster.
 
 If gRPC is enabled for a given pod, that `whereami` pod will not respond to HTTP requests, and any downstream service calls that the pod makes will also use gRPC only.
 

--- a/whereami/app.py
+++ b/whereami/app.py
@@ -2,7 +2,6 @@ from flask import Flask, request, Response, jsonify
 import logging
 import sys
 import os
-import json
 from flask_cors import CORS
 import whereami_payload
 

--- a/whereami/app.py
+++ b/whereami/app.py
@@ -86,6 +86,11 @@ def home(path):
 
     payload = whereami_payload.build_payload(request.headers)
 
+    # split the path to see if user wants to read a specific field
+    requested_value = path.split('/')[-1]
+    if requested_value in payload.keys():
+        return payload[requested_value]
+
     return jsonify(payload)
 
 if __name__ == '__main__':

--- a/whereami/app.py
+++ b/whereami/app.py
@@ -1,7 +1,8 @@
-from flask import Flask, request, Response, jsonify
+from flask import Flask, request, Response, jsonify, make_response
 import logging
 import sys
 import os
+import json
 from flask_cors import CORS
 import whereami_payload
 
@@ -89,6 +90,7 @@ def home(path):
     # split the path to see if user wants to read a specific field
     requested_value = path.split('/')[-1]
     if requested_value in payload.keys():
+        
         return payload[requested_value]
 
     return jsonify(payload)

--- a/whereami/app.py
+++ b/whereami/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, request, Response, jsonify, make_response
+from flask import Flask, request, Response, jsonify
 import logging
 import sys
 import os
@@ -90,7 +90,7 @@ def home(path):
     # split the path to see if user wants to read a specific field
     requested_value = path.split('/')[-1]
     if requested_value in payload.keys():
-        
+
         return payload[requested_value]
 
     return jsonify(payload)

--- a/whereami/k8s-grpc/deployment.yaml
+++ b/whereami/k8s-grpc/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: whereami-grpc-ksa
       containers:
       - name: whereami-grpc
-        image: gcr.io/google-samples/whereami:v1.1.3
+        image: gcr.io/google-samples/whereami:v1.1.4
         ports:
           - name: grpc
             containerPort: 9090

--- a/whereami/k8s/deployment.yaml
+++ b/whereami/k8s/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: whereami-ksa
       containers:
       - name: whereami
-        image: gcr.io/google-samples/whereami:v1.1.3
+        image: gcr.io/google-samples/whereami:v1.1.4
         ports:
           - name: http
             containerPort: 8080

--- a/whereami/requirements.txt
+++ b/whereami/requirements.txt
@@ -1,6 +1,6 @@
 flask
 requests
-emoji
+emoji>=1.2.0
 flask-cors
 grpcio
 grpcio-reflection

--- a/whereami/whereami_payload.py
+++ b/whereami/whereami_payload.py
@@ -14,7 +14,7 @@ METADATA_URL = 'http://metadata.google.internal/computeMetadata/v1/'
 METADATA_HEADERS = {'Metadata-Flavor': 'Google'}
 
 # set up emoji list
-emoji_list = list(emoji.unicode_codes.UNICODE_EMOJI.keys())
+emoji_list = list(emoji.unicode_codes.UNICODE_EMOJI['en'].keys())
 
 
 class WhereamiPayload(object):


### PR DESCRIPTION
per request from @mark-church 
```
Random Q ... are there any endpoints for which I can get just a subset of the information that whereami provides
like
curl ${VIP}/pod_name
bar-v2-6bbbd94c98-f4kvv
```

So now if you hit a `whereami` pod at some path, if the end of the path matches a field name in the JSON payload `whereami` typically returns, it gets returned as plaintext. Ex:

```bash
$ curl $ENDPOINT/some/path/prefix/pod_name_emoji

🧚🏽
```