### PR TITLE
Updating Dockerfile to remove PEAR

### DIFF
--- a/guestbook/php-redis/Dockerfile
+++ b/guestbook/php-redis/Dockerfile
@@ -11,11 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM php:7.4.7-apache
+FROM php:7.4-apache-buster
+RUN apt update && apt -y install zip unzip git-all
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
-RUN pear channel-discover pear.nrk.io
-RUN pear install nrk/Predis
+COPY . .
 
-ADD guestbook.php /var/www/html/guestbook.php
-ADD controllers.js /var/www/html/controllers.js
-ADD index.html /var/www/html/index.html
+RUN composer update

--- a/guestbook/php-redis/composer.json
+++ b/guestbook/php-redis/composer.json
@@ -1,0 +1,7 @@
+{
+    "name": "googlecloud/php-redis",
+    "license": "Apache2",
+    "require": {
+        "predis/predis" : "^1.1.6"
+    }
+}


### PR DESCRIPTION
Hi,

I got feedback about this Docker image because it uses `pear` which has been avoided lately in favor of `composer`.

The last line for `composer update` is there because since there is no lock file, the recommendation is not to user `composer install` but rather `composer update`.