### PR TITLE
moved from assuming HTTP to assuming HTTP or HTTPS prefix on backend_service calls

### DIFF
--- a/whereami/Dockerfile
+++ b/whereami/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   wget && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* && \
-  wget -O /bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.3.3/grpc_health_probe-linux-amd64 && \ 
+  wget -O /bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.3.6/grpc_health_probe-linux-amd64 && \ 
   chmod +x /bin/grpc_health_probe
 
 COPY ./requirements.txt /app/requirements.txt

--- a/whereami/README.md
+++ b/whereami/README.md
@@ -11,7 +11,7 @@
 `whereami` is a single-container app, designed and packaged to run on Kubernetes. In it's simplest form it can be deployed in a single line with only a few parameters.
 
 ```bash
-$ kubectl run --image=gcr.io/google-samples/whereami:v.1.2.1 --expose --port 8080 whereami
+$ kubectl run --image=gcr.io/google-samples/whereami:v1.2.1 --expose --port 8080 whereami
 ```
 
 The `whereami`  pod listens on port `8080` and returns a very simple JSON response that indicates who is responding and where they live. This example assumes you're executing the `curl` command from a pod in the same K8s cluster & namespace (although the following examples show how to access from external clients):
@@ -96,7 +96,7 @@ spec:
       serviceAccountName: whereami-ksa
       containers:
       - name: whereami
-        image: gcr.io/google-samples/whereami:v.1.2.1
+        image: gcr.io/google-samples/whereami:v1.2.1
         ports:
           - name: http
             containerPort: 8080 #The application is listening on port 8080

--- a/whereami/README.md
+++ b/whereami/README.md
@@ -11,7 +11,7 @@
 `whereami` is a single-container app, designed and packaged to run on Kubernetes. In it's simplest form it can be deployed in a single line with only a few parameters.
 
 ```bash
-$ kubectl run --image=gcr.io/google-samples/whereami:v1.2.0 --expose --port 8080 whereami
+$ kubectl run --image=gcr.io/google-samples/whereami:v.1.2.1 --expose --port 8080 whereami
 ```
 
 The `whereami`  pod listens on port `8080` and returns a very simple JSON response that indicates who is responding and where they live. This example assumes you're executing the `curl` command from a pod in the same K8s cluster & namespace (although the following examples show how to access from external clients):
@@ -96,7 +96,7 @@ spec:
       serviceAccountName: whereami-ksa
       containers:
       - name: whereami
-        image: gcr.io/google-samples/whereami:v1.2.0
+        image: gcr.io/google-samples/whereami:v.1.2.1
         ports:
           - name: http
             containerPort: 8080 #The application is listening on port 8080
@@ -217,6 +217,8 @@ The fields/path suffixes that are *always* available in a HTTP `whereami` respon
 
 `whereami` has an optional flag within its configmap that will cause it to call another backend service within your Kubernetes cluster (for example, a different, non-public instance of itself). This is helpful for demonstrating a public microservice call to a non-public microservice, and then including the responses of both microservices in the payload delivered back to the user.
 
+> Note: when defining a backend service to call via HTTP, make sure the `BACKEND_SERVICE` endpoint indicates either an `http://` or `https://` prefix.
+
 #### Step 1 - Deploy the whereami backend
 
 Deploy `whereami` again using the manifests from [k8s-backend-overlay-example](k8s-backend-overlay-example)
@@ -265,7 +267,8 @@ metadata:
   name: whereami-configmap
 data:
   BACKEND_ENABLED: "True" #This enables requests to be send to the backend
-  BACKEND_SERVICE: "whereami-backend" #This is the name of the backend Service that was created in the previous step
+  # when defining the BACKEND_SERVICE using an HTTP protocol, indicate HTTP or HTTPS; if using gRPC, use the host name only
+  BACKEND_SERVICE: "http://whereami-backend" #This is the name of the backend Service that was created in the previous step
   METADATA:        "frontend" #This is the metadata string returned in the output
 ```
 
@@ -467,7 +470,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   wget && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* && \
-  wget -O /bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.3.3/grpc_health_probe-linux-amd64 && \
+  wget -O /bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.3.6/grpc_health_probe-linux-amd64 && \
   chmod +x /bin/grpc_health_probe
 USER cnb
 EOF

--- a/whereami/k8s-frontend-overlay-example/cm-flag.yaml
+++ b/whereami/k8s-frontend-overlay-example/cm-flag.yaml
@@ -3,6 +3,7 @@ kind: ConfigMap
 metadata:
   name: whereami-configmap
 data:
-  BACKEND_ENABLED: "True" 
-  BACKEND_SERVICE: "whereami-backend" # substitute with corresponding service name - this example assumes both services are in the same namespace  
+  BACKEND_ENABLED: "True"
+  # when defining the BACKEND_SERVICE using an HTTP protocol, indicate HTTP or HTTPS; if using gRPC, use the host name only
+  BACKEND_SERVICE: "http://whereami-backend" # substitute with corresponding service name - this example assumes both services are in the same namespace and is unencrypted HTTP
   METADATA: "frontend"

--- a/whereami/k8s-grpc-backend-overlay-example/cm-flag.yaml
+++ b/whereami/k8s-grpc-backend-overlay-example/cm-flag.yaml
@@ -3,7 +3,8 @@ kind: ConfigMap
 metadata:
   name: whereami-grpc-configmap
 data:
-  BACKEND_ENABLED: "False" 
+  BACKEND_ENABLED: "False"
+  # when defining the BACKEND_SERVICE using an HTTP protocol, indicate HTTP or HTTPS; if using gRPC, use the host name only
   BACKEND_SERVICE: "whereami-grpc-backend" # substitute with corresponding service name - this example assumes both services are in the same namespace  
   METADATA: "grpc-backend"
   GRPC_ENABLED: "True"

--- a/whereami/k8s-grpc-frontend-overlay-example/cm-flag.yaml
+++ b/whereami/k8s-grpc-frontend-overlay-example/cm-flag.yaml
@@ -3,7 +3,8 @@ kind: ConfigMap
 metadata:
   name: whereami-grpc-configmap
 data:
-  BACKEND_ENABLED: "True" 
+  BACKEND_ENABLED: "True"
+  # when defining the BACKEND_SERVICE using an HTTP protocol, indicate HTTP or HTTPS; if using gRPC, use the host name only
   BACKEND_SERVICE: "whereami-grpc-backend" # substitute with corresponding service name - this example assumes both services are in the same namespace  
   METADATA: "grpc-frontend"
   GRPC_ENABLED: "True"

--- a/whereami/k8s-grpc/configmap.yaml
+++ b/whereami/k8s-grpc/configmap.yaml
@@ -4,6 +4,7 @@ metadata:
   name: whereami-grpc-configmap
 data:
   BACKEND_ENABLED: "False" # flag to enable backend service call "False" || "True"
+  # when defining the BACKEND_SERVICE using an HTTP protocol, indicate HTTP or HTTPS; if using gRPC, use the host name only
   BACKEND_SERVICE: "whereami-grpc-backend" # substitute with corresponding service name - this example assumes both services are in the same namespace  
   METADATA:        "grpc-frontend" # arbitrary string that gets returned in payload - can be used to track which services you're interacting with 
   ECHO_HEADERS:    "False" # flag to enable the payload including all headers received in the `echo_headers` field if set to "True". Ignored if using gRPC.

--- a/whereami/k8s-grpc/deployment.yaml
+++ b/whereami/k8s-grpc/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: whereami-grpc-ksa
       containers:
       - name: whereami-grpc
-        image: gcr.io/google-samples/whereami:v1.2.0
+        image: gcr.io/google-samples/whereami:v1.2.1
         ports:
           - name: grpc
             containerPort: 9090

--- a/whereami/k8s/configmap.yaml
+++ b/whereami/k8s/configmap.yaml
@@ -4,7 +4,8 @@ metadata:
   name: whereami-configmap
 data:
   BACKEND_ENABLED: "False" # flag to enable backend service call "False" || "True"
-  BACKEND_SERVICE: "whereami-backend" # substitute with corresponding service name - this example assumes both services are in the same namespace  
+  # when defining the BACKEND_SERVICE using an HTTP protocol, indicate HTTP or HTTPS; if using gRPC, use the host name only
+  BACKEND_SERVICE: "http://whereami-backend" # substitute with corresponding service name - this example assumes both services are in the same namespace  
   METADATA:        "frontend" # arbitrary string that gets returned in payload - can be used to track which services you're interacting with 
   ECHO_HEADERS:    "False" # flag to enable the payload including all headers received in the `echo_headers` field if set to "True"
   GRPC_ENABLED:    "False" # flag to switch whereami service to gRPC mode

--- a/whereami/k8s/deployment.yaml
+++ b/whereami/k8s/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: whereami-ksa
       containers:
       - name: whereami
-        image: gcr.io/google-samples/whereami:v.1.2.1
+        image: gcr.io/google-samples/whereami:v1.2.1
         ports:
           - name: http
             containerPort: 8080

--- a/whereami/k8s/deployment.yaml
+++ b/whereami/k8s/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: whereami-ksa
       containers:
       - name: whereami
-        image: gcr.io/google-samples/whereami:v1.2.0
+        image: gcr.io/google-samples/whereami:v.1.2.1
         ports:
           - name: http
             containerPort: 8080

--- a/whereami/whereami_payload.py
+++ b/whereami/whereami_payload.py
@@ -144,7 +144,7 @@ class WhereamiPayload(object):
             else:
 
                 try:
-                    r = requests.get('http://' + backend_service,
+                    r = requests.get(backend_service,
                                      headers=getForwardHeaders(request_headers))
                     if r.ok:
                         backend_result = r.json()


### PR DESCRIPTION
prior versions assumed an `http://` prefix when calling `backend_service`. This broke any backend calls to `https://` endpoints. This PR updates both the source code as well as the `ConfigMap` YAML to expect either an `http://` or `https://` prefix, unless using `gRPC`. Also the `deployment.yaml` docs reference a new image build of `v1.2.1`.