### PR TITLE
Rebase sd-dummy-exporter to distroless

### DIFF
--- a/custom-metrics-autoscaling/direct-to-sd/Dockerfile
+++ b/custom-metrics-autoscaling/direct-to-sd/Dockerfile
@@ -12,13 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.12.5
-ADD . /go/src/direct-to-sd
+FROM golang:1.15.11
+ADD . /go/src/sd-dummy-exporter
 RUN go get cloud.google.com/go/compute/metadata
 RUN go get golang.org/x/oauth2
 RUN go get cloud.google.com/go/monitoring/apiv3
-RUN CGO_ENABLED=0 GOOS=linux go install direct-to-sd
+RUN CGO_ENABLED=0 GOOS=linux go install sd-dummy-exporter
 
-FROM alpine:latest
-RUN apk -U add ca-certificates
-COPY --from=0 /go/bin/direct-to-sd .
+FROM gcr.io/distroless/static:latest
+COPY --from=0 /go/bin/sd-dummy-exporter .

--- a/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd.yaml
+++ b/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd.yaml
@@ -31,7 +31,7 @@ spec:
         run: custom-metric-sd
     spec:
       containers:
-      - command: ["./sd_dummy_exporter"]
+      - command: ["./sd-dummy-exporter"]
         args:
         - --use-new-resource-model=true
         - --use-old-resource-model=false
@@ -39,7 +39,7 @@ spec:
         - --metric-value=40
         - --pod-name=$(POD_NAME)
         - --namespace=$(NAMESPACE)
-        image: gcr.io/google-containers/sd-dummy-exporter:v0.2.0
+        image: gcr.io/google-samples/sd-dummy-exporter:latest
         name: sd-dummy-exporter
         resources:
           requests:

--- a/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd.yaml
+++ b/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd.yaml
@@ -39,7 +39,7 @@ spec:
         - --metric-value=40
         - --pod-name=$(POD_NAME)
         - --namespace=$(NAMESPACE)
-        image: gcr.io/google-samples/sd-dummy-exporter:latest
+        image: gcr.io/google-samples/sd-dummy-exporter:v0.3.0
         name: sd-dummy-exporter
         resources:
           requests:


### PR DESCRIPTION
Why?
This fixes some CVE issues [1] with gcr.io/google-containers/sd-dummy-exporter:v0.2.0, which is based on
alpine:latest.

[1] CVE-2018-12020 CVE-2017-12837 CVE-2018-15688 CVE-2017-10140
CVE-2017-7526 CVE-2018-6913 CVE-2018-16864 CVE-2017-12883 CVE-2018-12015
CVE-2018-16865

I also moved this image to gcr.io/google-samples/ for consistency with the rest of the images under GoogleCloudPlatform/kubernetes-engine-samples. 