### PR TITLE
Rebase prometheus-dummy-exporter on distroless

### DIFF
--- a/custom-metrics-autoscaling/prometheus-to-sd/Dockerfile
+++ b/custom-metrics-autoscaling/prometheus-to-sd/Dockerfile
@@ -17,5 +17,5 @@ ADD . /go/src/prometheus-dummy-exporter
 RUN go get github.com/prometheus/client_golang/prometheus
 RUN CGO_ENABLED=0 GOOS=linux go install prometheus-dummy-exporter
 
-FROM alpine:latest
+FROM gcr.io/distroless/static:latest
 COPY --from=0 /go/bin/prometheus-dummy-exporter .

--- a/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd.yaml
+++ b/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd.yaml
@@ -33,8 +33,8 @@ spec:
       containers:
       # sample container generating custom metrics
       - name: prometheus-dummy-exporter
-        image: gcr.io/google-containers/prometheus-dummy-exporter:v0.1.0
-        command: ["./prometheus_dummy_exporter"]
+        image: gcr.io/google-samples/prometheus-dummy-exporter:v0.2.0
+        command: ["./prometheus-dummy-exporter"]
         args:
         - --metric-name=custom_prometheus
         - --metric-value=40


### PR DESCRIPTION
This fixes some CVE issues [1] found in
gcr.io/google-containers/prometheus-dummy-exporter:v0.1.0, which is
based on alpine:latest

[1] CVE-2017-12883 CVE-2017-10140 CVE-2018-16865 CVE-2018-6913
CVE-2018-12015 CVE-2018-12020 CVE-2017-7526 CVE-2018-16864
CVE-2017-12837 CVE-2018-15688