### PR TITLE
Bump gke-windows-builder version to 2.5.0

### DIFF
--- a/windows-multi-arch/cloudbuild.yaml
+++ b/windows-multi-arch/cloudbuild.yaml
@@ -15,7 +15,7 @@
 # [START container_windows_multi_arch_cloudbuild]
 timeout: 3600s
 steps:
-- name: 'gcr.io/gke-release/gke-windows-builder:release-2.0.0-gke.0'
+- name: 'gcr.io/gke-release/gke-windows-builder:release-2.5.0-gke.0'
   args:
   - --container-image-name
   - 'gcr.io/$PROJECT_ID/multiarch-helloworld:latest'


### PR DESCRIPTION
Fixes from version 2.0.0 -> 2.5.0 include:

- Add Windows Server 2004 and 20H2 arch's, remove 1909 arch.
- Add boot-disk-type flag.
- Add logic to create a bucket to copy workspace if not exists
- Move the Winrm setup to last step to reduce the chance of failures
- Add bootDiskSizeGB option
- Disable Windows Defender to avoid accasional docker build failures
- Fail the building process if errors happen