### PR TITLE
Add cloudbuild.yaml for hello-app:1.0 & 2.0

### DIFF
--- a/hello-app/cloudbuild.yaml
+++ b/hello-app/cloudbuild.yaml
@@ -1,0 +1,32 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file and other cloudbuild.yaml files are used to ensure that
+# our public Docker images such as gcr.io/google-samples/hello-app:1.0
+# are rebuilt and updated upon changes to the repository.
+
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+    - 'build'
+    - '-t'
+    - 'gcr.io/google-samples/hello-app:1.0'
+    - '-t'
+    - 'us-docker.pkg.dev/google-samples/containers/gke/hello-app:1.0'
+    - '.'
+  dir: 'hello-app'
+
+images:
+  - 'gcr.io/google-samples/hello-app:1.0'
+  - 'us-docker.pkg.dev/google-samples/containers/gke/hello-app:1.0'

--- a/hello-app/cloudbuild.yaml
+++ b/hello-app/cloudbuild.yaml
@@ -17,6 +17,8 @@
 # are rebuilt and updated upon changes to the repository.
 
 steps:
+
+# Build hello-app:1.0.
 - name: 'gcr.io/cloud-builders/docker'
   args:
     - 'build'
@@ -27,6 +29,32 @@ steps:
     - '.'
   dir: 'hello-app'
 
+# Copy hello-app to /workspace.
+- name: 'bash'
+  args:
+    - '-c'
+    - cp -r hello-app/ /workspace
+
+# Copy main.go to /workspace, with "Version: 1.0.0" replaced by "Version: 2.0.0".
+- name: 'bash'
+  args:
+    - '-c'
+    - 'sed "s/Version: 1.0.0/Version: 2.0.0/" hello-app/main.go > /workspace/main.go'
+
+# Build hello-app:2.0 from /workspace.
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+    - 'build'
+    - '-t'
+    - 'gcr.io/google-samples/hello-app:2.0'
+    - '-t'
+    - 'us-docker.pkg.dev/google-samples/containers/gke/hello-app:2.0'
+    - '.'
+  dir: '/workspace'
+
+# Push images.
 images:
   - 'gcr.io/google-samples/hello-app:1.0'
   - 'us-docker.pkg.dev/google-samples/containers/gke/hello-app:1.0'
+  - 'gcr.io/google-samples/hello-app:2.0'
+  - 'us-docker.pkg.dev/google-samples/containers/gke/hello-app:2.0'


### PR DESCRIPTION
This pull-request simply adds a `cloudbuild.yaml` file that tells [Google Cloud Build](https://cloud.google.com/build) to build and push the image `hello-app:1.0` image at:
* `gcr.io/google-samples/hello-app:1.0`
* `us-docker.pkg.dev/google-samples/containers/gke/hello-app:1.0`
  
Some concerns:

1. I have yet to create the associated Cloud Build trigger. We still need to decide on which GCP project to use for the Cloud Build triggers. @donmccasland mentioned that we will be using the `google-samples` projects, but @askmeegs mentioned that it might be better to use a different project.

2. The comment at the top of the cloudbuild.yaml file might be redundant but I've added it in case the users of our GKE tutorials are confused by the file.

3. This commit only builds hello-app:1.0. It does not build hello-app:2.0. @askmeegs pointed out that we will need to update the [main.go file](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/master/hello-app/main.go#L48) (i.e., replace `"Version: 1.0.0\n"`) and _then_ build and push hello-app:2.0. I am currently looking at how we can [pass data between Cloud Build steps](https://medium.com/google-cloud/how-to-pass-data-between-cloud-build-steps-de5c9ebc4cdd) to see if I can replace the version number via Cloud Build itself. I may need to consult Dina on this. 

4. I've used `us-docker.pkg.dev/google-samples/containers/gke/hello-app:1.0` for the Artifact Registry URL. I chose this URL because it had already been created (in [Oct 2020](https://pantheon.corp.google.com/artifacts/docker/google-samples/us/containers/gke%2Fhello-app?project=google-samples)).