### PR TITLE
Add cloudbuild.yaml files for 9 images

### DIFF
--- a/cloud-pubsub/cloudbuild.yaml
+++ b/cloud-pubsub/cloudbuild.yaml
@@ -1,0 +1,32 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file and other cloudbuild.yaml files are used to ensure that
+# our public Docker images such as us-docker.pkg.dev/google-samples/containers/gke/pubsub-sample:v1
+# are rebuilt and updated upon changes to the repository.
+
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+    - 'build'
+    - '-t'
+    - 'gcr.io/google-samples/pubsub-sample:v1'
+    - '-t'
+    - 'us-docker.pkg.dev/google-samples/containers/gke/pubsub-sample:v1'
+    - '.'
+  dir: 'cloud-pubsub'
+
+images:
+  - 'gcr.io/google-samples/pubsub-sample:v1'
+  - 'us-docker.pkg.dev/google-samples/containers/gke/pubsub-sample:v1'

--- a/custom-metrics-autoscaling/direct-to-sd/cloudbuild.yaml
+++ b/custom-metrics-autoscaling/direct-to-sd/cloudbuild.yaml
@@ -1,0 +1,32 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file and other cloudbuild.yaml files are used to ensure that
+# our public Docker images such as us-docker.pkg.dev/google-samples/containers/gke/sd-dummy-exporter:v0.3.0
+# are rebuilt and updated upon changes to the repository.
+
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+    - 'build'
+    - '-t'
+    - 'gcr.io/google-samples/sd-dummy-exporter:v0.3.0'
+    - '-t'
+    - 'us-docker.pkg.dev/google-samples/containers/gke/sd-dummy-exporter:v0.3.0'
+    - '.'
+  dir: 'custom-metrics-autoscaling/direct-to-sd'
+
+images:
+  - 'gcr.io/google-samples/sd-dummy-exporter:v0.3.0'
+  - 'us-docker.pkg.dev/google-samples/containers/gke/sd-dummy-exporter:v0.3.0'

--- a/custom-metrics-autoscaling/prometheus-to-sd/cloudbuild.yaml
+++ b/custom-metrics-autoscaling/prometheus-to-sd/cloudbuild.yaml
@@ -1,0 +1,32 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file and other cloudbuild.yaml files are used to ensure that
+# our public Docker images such as us-docker.pkg.dev/google-samples/containers/gke/prometheus-dummy-exporter:v0.2.0
+# are rebuilt and updated upon changes to the repository.
+
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+    - 'build'
+    - '-t'
+    - 'gcr.io/google-samples/prometheus-dummy-exporter:v0.2.0'
+    - '-t'
+    - 'us-docker.pkg.dev/google-samples/containers/gke/prometheus-dummy-exporter:v0.2.0'
+    - '.'
+  dir: 'custom-metrics-autoscaling/prometheus-to-sd'
+
+images:
+  - 'gcr.io/google-samples/prometheus-dummy-exporter:v0.2.0'
+  - 'us-docker.pkg.dev/google-samples/containers/gke/prometheus-dummy-exporter:v0.2.0'

--- a/guestbook/php-redis/cloudbuild.yaml
+++ b/guestbook/php-redis/cloudbuild.yaml
@@ -1,0 +1,32 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file and other cloudbuild.yaml files are used to ensure that
+# our public Docker images such as us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5
+# are rebuilt and updated upon changes to the repository.
+
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+    - 'build'
+    - '-t'
+    - 'gcr.io/google-samples/gb-frontend:v5'
+    - '-t'
+    - 'us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5'
+    - '.'
+  dir: 'guestbook/php-redis'
+
+images:
+  - 'gcr.io/google-samples/gb-frontend:v5'
+  - 'us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5'

--- a/guestbook/redis-follower/cloudbuild.yaml
+++ b/guestbook/redis-follower/cloudbuild.yaml
@@ -1,0 +1,32 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file and other cloudbuild.yaml files are used to ensure that
+# our public Docker images such as us-docker.pkg.dev/google-samples/containers/gke/gb-redis-follower:v2
+# are rebuilt and updated upon changes to the repository.
+
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+    - 'build'
+    - '-t'
+    - 'gcr.io/google-samples/gb-redis-follower:v2'
+    - '-t'
+    - 'us-docker.pkg.dev/google-samples/containers/gke/gb-redis-follower:v2'
+    - '.'
+  dir: 'guestbook/redis-follower'
+
+images:
+  - 'gcr.io/google-samples/gb-redis-follower:v2'
+  - 'us-docker.pkg.dev/google-samples/containers/gke/gb-redis-follower:v2'

--- a/hello-app-cdn/cloudbuild.yaml
+++ b/hello-app-cdn/cloudbuild.yaml
@@ -1,0 +1,32 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file and other cloudbuild.yaml files are used to ensure that
+# our public Docker images such as us-docker.pkg.dev/google-samples/containers/gke/hello-app-cdn:1.0
+# are rebuilt and updated upon changes to the repository.
+
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+    - 'build'
+    - '-t'
+    - 'gcr.io/google-samples/hello-app-cdn:1.0'
+    - '-t'
+    - 'us-docker.pkg.dev/google-samples/containers/gke/hello-app-cdn:1.0'
+    - '.'
+  dir: 'hello-app-cdn'
+
+images:
+  - 'gcr.io/google-samples/hello-app-cdn:1.0'
+  - 'us-docker.pkg.dev/google-samples/containers/gke/hello-app-cdn:1.0'

--- a/hello-app-redis/cloudbuild.yaml
+++ b/hello-app-redis/cloudbuild.yaml
@@ -1,0 +1,32 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file and other cloudbuild.yaml files are used to ensure that
+# our public Docker images such as us-docker.pkg.dev/google-samples/containers/gke/hello-app-redis:1.0
+# are rebuilt and updated upon changes to the repository.
+
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+    - 'build'
+    - '-t'
+    - 'gcr.io/google-samples/hello-app-redis:1.0'
+    - '-t'
+    - 'us-docker.pkg.dev/google-samples/containers/gke/hello-app-redis:1.0'
+    - '.'
+  dir: 'hello-app-redis'
+
+images:
+  - 'gcr.io/google-samples/hello-app-redis:1.0'
+  - 'us-docker.pkg.dev/google-samples/containers/gke/hello-app-redis:1.0'

--- a/hello-app-tls/cloudbuild.yaml
+++ b/hello-app-tls/cloudbuild.yaml
@@ -1,0 +1,32 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file and other cloudbuild.yaml files are used to ensure that
+# our public Docker images such as us-docker.pkg.dev/google-samples/containers/gke/hello-app-tls:1.0
+# are rebuilt and updated upon changes to the repository.
+
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+    - 'build'
+    - '-t'
+    - 'gcr.io/google-samples/hello-app-tls:1.0'
+    - '-t'
+    - 'us-docker.pkg.dev/google-samples/containers/gke/hello-app-tls:1.0'
+    - '.'
+  dir: 'hello-app-tls'
+
+images:
+  - 'gcr.io/google-samples/hello-app-tls:1.0'
+  - 'us-docker.pkg.dev/google-samples/containers/gke/hello-app-tls:1.0'

--- a/whereami/cloudbuild.yaml
+++ b/whereami/cloudbuild.yaml
@@ -1,0 +1,32 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file and other cloudbuild.yaml files are used to ensure that
+# our public Docker images such as us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.1
+# are rebuilt and updated upon changes to the repository.
+
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+    - 'build'
+    - '-t'
+    - 'gcr.io/google-samples/whereami:v1.2.1'
+    - '-t'
+    - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.1'
+    - '.'
+  dir: 'whereami'
+
+images:
+  - 'gcr.io/google-samples/whereami:v1.2.1'
+  - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.1'


### PR DESCRIPTION
Before merging this PR, we should first merge and test https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/pull/184.

These `cloudbuild.yaml` files will tell Google Cloud Build to automatically rebuild and re-push various Docker images to their associated Google Container Registry (gcr.io) and Artifact Registry (us-docker.pkg.dev) URLs.

This repository contains 19 Dockerfiles, but only 10 of the Dockerfiles currently have associated images on Google Container Registry (i.e., gcr.io URLs). See [this internal Google Sheet](https://docs.google.com/spreadsheets/d/1e2QHD5YgN0-TCwWipaVwk7HSJD40-zHUXIHg4H3g6VM/edit#gid=0) for the details.

This pull-request addresses 9 Dockerfiles.