### PR TITLE
Revert "fix: update dockerfile to use composer instead of pear (#171)"

### DIFF
--- a/guestbook/php-redis/Dockerfile
+++ b/guestbook/php-redis/Dockerfile
@@ -11,10 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM php:7.4-apache-buster
-RUN apt update && apt -y install zip unzip git-all
-COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+FROM php:7.4.7-apache
 
-COPY . .
+RUN pear channel-discover pear.nrk.io
+RUN pear install nrk/Predis
 
-RUN composer update
+ADD guestbook.php /var/www/html/guestbook.php
+ADD controllers.js /var/www/html/controllers.js
+ADD index.html /var/www/html/index.html

--- a/guestbook/php-redis/composer.json
+++ b/guestbook/php-redis/composer.json
@@ -1,7 +1,0 @@
-{
-    "name": "googlecloud/php-redis",
-    "license": "Apache2",
-    "require": {
-        "predis/predis" : "^1.1.6"
-    }
-}


### PR DESCRIPTION
This reverts commit 41c22011b7b66672f9815bd762fbbc4d7e96ef72.

There's a long story of how I got here, but the TL;DR is: #171 is a breaking change that results in https://cloud.google.com/kubernetes-engine/docs/tutorials/guestbook and other tutorials not working due to the missing `Predis` package.

I don't know enough about the code to fix using pear or alternative solution, but a revert does fix it and I've proved it out w/ [this personal publicly built image](https://hub.docker.com/repository/docker/jimangel/php-guestbook-revert).

Without the revert, php never finds `Predis` and errors out (no data / connection):

![image](https://user-images.githubusercontent.com/4601051/122331189-079fef80-cefa-11eb-89ff-ff0fb8fe2b6d.png)

With the revert, php finds `Redis` and things work:

![image](https://user-images.githubusercontent.com/4601051/122331164-fd7df100-cef9-11eb-8226-ccd68e4fc407.png)

I was able to connect the dots when the error I googled led me to a [discussion around `compose install` vs `compose upgrade`](https://stackoverflow.com/a/41209642) and [the PR](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/pull/171#issue-585048759) had comments around the same.

There's probably a better solution using `compose`, but I don't have the time to figure it out and this is a way to get things operational again. Thanks!

/cc @gabidavila