### PR TITLE
Replace use of GCR with AR for guestbook

### DIFF
--- a/guestbook/all-in-one/frontend.yaml
+++ b/guestbook/all-in-one/frontend.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
       - name: php-redis
-        image: gcr.io/google_samples/gb-frontend:v5
+        image: us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5
         env:
         - name: GET_HOSTS_FROM
           value: "dns"

--- a/guestbook/all-in-one/guestbook-all-in-one.yaml
+++ b/guestbook/all-in-one/guestbook-all-in-one.yaml
@@ -84,7 +84,7 @@ spec:
     spec:
       containers:
       - name: follower
-        image: gcr.io/google_samples/gb-redis-follower:v2
+        image: us-docker.pkg.dev/google-samples/containers/gke/gb-redis-follower:v2
         resources:
           requests:
             cpu: 100m
@@ -126,7 +126,7 @@ spec:
     spec:
       containers:
       - name: php-redis
-        image: gcr.io/google_samples/gb-frontend:v5
+        image: us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5
         env:
         - name: GET_HOSTS_FROM
           value: "dns"

--- a/guestbook/all-in-one/redis-follower.yaml
+++ b/guestbook/all-in-one/redis-follower.yaml
@@ -37,7 +37,7 @@ spec:
     spec:
       containers:
       - name: follower
-        image: gcr.io/google_samples/gb-redis-follower:v2
+        image: us-docker.pkg.dev/google-samples/containers/gke/gb-redis-follower:v2
         resources:
           requests:
             cpu: 100m

--- a/guestbook/frontend-deployment.yaml
+++ b/guestbook/frontend-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: php-redis
-        image: gcr.io/google_samples/gb-frontend:v5
+        image: us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5
         env:
         - name: GET_HOSTS_FROM
           value: "dns"

--- a/guestbook/redis-follower-deployment.yaml
+++ b/guestbook/redis-follower-deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: follower
-        image: gcr.io/google_samples/gb-redis-follower:v2
+        image: us-docker.pkg.dev/google-samples/containers/gke/gb-redis-follower:v2
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
## Background
* We want to encourage customers to use Google Artifact Registry (AR) instead of Google Container Registry (GCR).
* We currently push Docker images from this repository to both AR and GCR (see https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/pull/185). Most tutorials still pull these images from GCR, but we want to eventually replaces all uses of GCR with AR.

## Change Summary
* The pull-request is for the following images:
  * `gcr.io/google_samples/gb-frontend:v5` 
    * → `us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5`
  * `gcr.io/google_samples/gb-redis-follower:v2`
    * → `us-docker.pkg.dev/google-samples/containers/gke/gb-redis-follower:v2` 

## Tutorials To Update
* The [Create a guestbook with Redis and PHP](https://cloud.google.com/kubernetes-engine/docs/tutorials/guestbook) tutorial asks users to checkout a specific commit (`git checkout abbb383`), so this pull-request won't affect the tutorial until we change that commit hash.
  * Once this pull-request is merged, we will need to create a changelist (CL) to update the commit hash in that tutorial.
 
## Manually Tested 👍
We can verify that the AR (replacement) images and GCR (replaced) images are equivalent like so:
1. Pull the 2 images you want to compare:
```
docker image pull gcr.io/google-samples/gb-frontend:v5
docker image pull us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5
```
2.  Inspecting both images:
```
docker image inspect gcr.io/google-samples/gb-frontend:v5
docker image inspect us-docker.pkg.dev/google-samples/containers/gke/gb-frontend:v5
```
3. See that the [RootFS values match](https://stackoverflow.com/questions/46321878/how-to-verify-if-the-content-of-two-docker-images-is-exactly-the-same/46322160#46322160).