### PR TITLE
Fix importing of composer libraries in guestbook.php

### DIFF
--- a/guestbook/php-redis/guestbook.php
+++ b/guestbook/php-redis/guestbook.php
@@ -19,9 +19,7 @@
 error_reporting(E_ALL);
 ini_set('display_errors', 1);
 
-require 'Predis/Autoloader.php';
-
-Predis\Autoloader::register();
+require __DIR__ . '/vendor/autoload.php';
 
 if (isset($_GET['cmd']) === true) {
   $host = 'redis-leader';


### PR DESCRIPTION
## Background

* The [Create a guestbook with Redis and PHP](https://cloud.google.com/kubernetes-engine/docs/tutorials/guestbook) tutorial is broken.
* More specifically, the PHP app inside the `gcr.io/google_samples/gb-frontend:v5` Docker image is broken.
* `guestbook.php` relies on a library called [Predis](https://github.com/predis/predis) to talk to Redis.
* We use [Composer](https://getcomposer.org/) to download the Predis library.

## The Issue

PHP Composer downloads the Predis library into a `vendor/predis/predis/src` folder, but `guestbook.php` imports the Predis library incorrectly:
```
require 'Predis/Autoloader.php';
```
which results in the following PHP error:
```
Warning: require(Predis/Autoloader.php): failed to open stream: No such file or directory in /var/www/html/guestbook.php on line 22

Fatal error: require(): Failed opening required 'Predis/Autoloader.php' (include_path='.:/usr/local/lib/php') in /var/www/html/guestbook.php on line 22
```

This error started occurring after [pull-request 171](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/pull/171) (which introduced the use of Composer). Before that, we used [Pear](https://pear.php.net/).

This issue is also addressed by [pull-request 190](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/pull/190).

We never noticed this error before because:
1. [pull-request 171](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/pull/171) was merged in March 2021
2. `gcr.io/google_samples/gb-frontend:v5` was later rebuilt/repushed in June 2021.

![Screenshot showing the broken guestbook.php.](https://user-images.githubusercontent.com/10292865/123281080-6277af00-d4d7-11eb-9863-90585e70bb47.png)

## The Solution

To import Composer dependencies, we use [Composer's autoloading feature](https://getcomposer.org/doc/01-basic-usage.md#autoloading):
```
require __DIR__ . '/vendor/autoload.php';
```

I have tested the new image (using my own Container Registry repo) and it works!

![Screenshot showing the fixed guestbook.php.](https://user-images.githubusercontent.com/10292865/123281094-65729f80-d4d7-11eb-9122-b5ef3110173b.png)