### PR TITLE
Use Artifact Registry in Quickstart's .yaml

### DIFF
--- a/quickstart/deployment.yaml
+++ b/quickstart/deployment.yaml
@@ -15,8 +15,9 @@ spec:
     spec:
       containers:
       - name: hello-app
-        # Replace $GCLOUD_PROJECT with your project ID
-        image: gcr.io/$GCLOUD_PROJECT/helloworld-gke:latest
+        # Replace $LOCATION with your Artifact Registry location (e.g., us-west1).
+        # Replace $GCLOUD_PROJECT with your project ID.
+        image: $LOCATION-docker.pkg.dev/$GCLOUD_PROJECT/hello-repo/helloworld-gke:latest
         # This app listens on port 8080 for web traffic by default.
         ports:
         - containerPort: 8080


### PR DESCRIPTION
## Background 

* We want to encourage customers to use Google Artifact Registry (AR) instead of Google Container Registry (GCR).
* We currently push Docker images from this repository to both AR and GCR (see https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/pull/185). Most tutorials still pull these images from GCR, but we want to eventually replaces all uses of GCR with AR.

## Summary of Change

* We are currently in the process of updating the [Quickstart: Deploying a language-specific app](https://cloud.google.com/kubernetes-engine/docs/quickstarts/deploying-a-language-specific-app#deploy_an_app) to use AR instead of GCR.
* This pull-request simply changes the image URL of `deployment.yaml`.

CC: @nyap