### PR TITLE
Bump version to 2.6.0

### DIFF
--- a/windows-multi-arch/cloudbuild.yaml
+++ b/windows-multi-arch/cloudbuild.yaml
@@ -15,7 +15,7 @@
 # [START container_windows_multi_arch_cloudbuild]
 timeout: 3600s
 steps:
-- name: 'gcr.io/gke-release/gke-windows-builder:release-2.5.0-gke.0'
+- name: 'gcr.io/gke-release/gke-windows-builder:release-2.6.0-gke.0'
   args:
   - --container-image-name
   - 'gcr.io/$PROJECT_ID/multiarch-helloworld:latest'


### PR DESCRIPTION
Changes from version 2.5.0 -> 2.6.0 include:

- Support for skipping firewall rule checks, using the `--skip-firewall-check` flag.
- Support for running builder VMs in Shared VPC service projects, using the `--subnetwork-project` and `--subnetwork` flags.