### PR TITLE
fix spacing issues wherami/grpc

### DIFF
--- a/whereami/k8s-grpc/service.yaml
+++ b/whereami/k8s-grpc/service.yaml
@@ -1,12 +1,12 @@
-  apiVersion: "v1"
-  kind: "Service"
-  metadata:
-    name: "whereami-grpc"
-  spec:
-    ports:
-    - port: 9090
-      protocol: TCP
-      name: grpc # adding for Istio
-    selector:
-      app: "whereami-grpc"
-    type: "LoadBalancer"
+apiVersion: "v1"
+kind: "Service"
+metadata:
+  name: "whereami-grpc"
+spec:
+  ports:
+  - port: 9090
+    protocol: TCP
+    name: grpc # adding for Istio
+  selector:
+    app: "whereami-grpc"
+  type: "LoadBalancer"


### PR DESCRIPTION
the service.yaml for the gRPC version of `whereami` had erroneous spacing. fixed now. 