### PR TITLE
Remove guestbook.php's redundant 'key' GET parameter

### DIFF
--- a/guestbook/php-redis/controllers.js
+++ b/guestbook/php-redis/controllers.js
@@ -25,7 +25,7 @@ RedisController.prototype.onRedis = function() {
     this.scope_.messages.push(this.scope_.msg);
     this.scope_.msg = "";
     var value = this.scope_.messages.join();
-    this.http_.get("guestbook.php?cmd=set&key=messages&value=" + value)
+    this.http_.get("guestbook.php?cmd=set&value=" + value)
             .success(angular.bind(this, function(data) {
                 this.scope_.redisResponse = "Updated.";
             }));
@@ -37,7 +37,7 @@ redisApp.controller('RedisCtrl', function ($scope, $http, $location) {
         $scope.controller.location_ = $location;
         $scope.controller.http_ = $http;
 
-        $scope.controller.http_.get("guestbook.php?cmd=get&key=messages")
+        $scope.controller.http_.get("guestbook.php?cmd=get")
             .success(function(data) {
                 console.log(data);
                 $scope.messages = data.data.split(",");

--- a/guestbook/php-redis/guestbook.php
+++ b/guestbook/php-redis/guestbook.php
@@ -34,7 +34,7 @@ if (isset($_GET['cmd']) === true) {
       'port'   => 6379,
     ]);
 
-    $client->set($_GET['key'], $_GET['value']);
+    $client->set('guestbook', $_GET['value']);
     print('{"message": "Updated"}');
   } else {
     $host = 'redis-follower';
@@ -47,7 +47,7 @@ if (isset($_GET['cmd']) === true) {
       'port'   => 6379,
     ]);
 
-    $value = $client->get($_GET['key']);
+    $value = $client->get('guestbook');
     print('{"data": "' . $value . '"}');
   }
 } else {


### PR DESCRIPTION
This addresses https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/issues/170.

**Background**
* The Guestbook sample app consists of:
  1. Redis key-value database - stores the list of names (i.e., guestbook).
  1. `guestbook.php` HTTP endpoint - allows for retrieval and modification of values at _any_ Redis key.
  1. AngularJS webpage - makes HTTP GET requests to `guestbook.php` (to store a string like `Jill Doe, John Doe, Jane Doe` in the Redis key-value store at key `messages`).

**Change Summary**
* `guestbook.php` now only allows for retrieval and modification of values at key `guestbook` — instead of allowing any key.
* The AngularJS webpage no longer specifies (to `guestbook.php`) the Redis key (`messages`) in which the guestbook (string of names) is stored.

**Things to Consider**
* Merging this pull-request will invoke a Cloud Build Trigger that rebuilds/repushes the Docker image at `gcr.io/google_samples/gb-frontend:v5`.  Perhaps we should increment `v5` to `v6` before merging.
  * In practice, one would increment `v5` to `v6`. But I don't think we need to in this case, because this doesn't change how our users interface with the tutorial.

**Manual Testing Passed**
* I have manually tested the changes in my own GKE cluster, and it works. 
![Screen Shot 2021-08-10 at 1 37 34 PM](https://user-images.githubusercontent.com/10292865/128907974-fd8b463d-d473-434b-a840-a69436b4739f.png)
