### PR TITLE
Update load-balancing/ Ingresses for K8 v1.22

### DIFF
--- a/load-balancing/basic-ingress-static.yaml
+++ b/load-balancing/basic-ingress-static.yaml
@@ -1,10 +1,12 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: basic-ingress
   annotations:
     kubernetes.io/ingress.global-static-ip-name: "web-static-ip"
 spec:
-  backend:
-    serviceName: web
-    servicePort: 8080
+  defaultBackend:
+    service:
+      name: web
+      port:
+        number: 8080

--- a/load-balancing/basic-ingress.yaml
+++ b/load-balancing/basic-ingress.yaml
@@ -1,8 +1,10 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: basic-ingress
 spec:
-  backend:
-    serviceName: web
-    servicePort: 8080
+  defaultBackend:
+    service:
+      name: web
+      port:
+        number: 8080

--- a/load-balancing/fanout-ingress.yaml
+++ b/load-balancing/fanout-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: fanout-ingress
@@ -7,10 +7,16 @@ spec:
   - http:
       paths:
       - path: /*
+        pathType: ImplementationSpecific
         backend:
-          serviceName: web
-          servicePort: 8080
+          service:
+            name: web
+            port:
+              number: 8080
       - path: /v2/*
+        pathType: ImplementationSpecific
         backend:
-          serviceName: web2
-          servicePort: 8080
+          service:
+            name: web2
+            port:
+              number: 8080


### PR DESCRIPTION
**Background**

* The `Ingress` manifests in `load-balancing/` use `apiVersion: networking.k8s.io/v1beta1`.
* See [Kubernetes v1.22 Migration Guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122):
  * Kubernetes v1.22 will not serve `networking.k8.io/v1beta1`, for `Ingress`. 
  * `networking.k8s.io/v1` should be used instead.
  * Some fields need to be changed (e.g., `serviceName` is now `service.name`).
* The current [default Kubernetes version](https://cloud.google.com/kubernetes-engine/versioning#use_to_check_versions) of the GKE **Stable** release channel is **v1.18**.
  * But this change needs at least **v1.19**. 
  * So this change will not work on GKE **Stable**, by default.
* Kubernetes v1.22 will be available in the GKE **Rapid** release channel in [September 2021](https://cloud.google.com/kubernetes-engine/docs/release-schedule#schedule_for_release_channels).
* [GKE `Ingress` documentation](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#multiple_backend_services) uses `apiVersion: networking.k8s.io/v1`, so let's be consistent with that.

**Summary of Pull-Request**

* We now use `apiVersion: networking.k8s.io/v1`.
* Fields now follow the `networking.k8.io/v1` specification of `Ingress` (e.g., `serviceName` is now `service.name`).

**Manually Tested**

I have tested the relevant tutorial ([Setting up HTTP(S) Load Balancing with Ingress](https://cloud.google.com/kubernetes-engine/docs/tutorials/http-balancer)) with the changes from this pull-request, and everything works!

Kubernetes version I tested on: `1.20.8-gke.900` (default version of GKE Rapid and GKE Regular)

`basic-ingress.yaml` ✅ 

![Screen Shot 2021-08-12 at 10 46 34 AM](https://user-images.githubusercontent.com/10292865/129218370-ee3f4402-6dba-4ec6-95fd-e59ec1b93c72.png)

`basic-ingress-static.yaml` ✅ 

![Screen Shot 2021-08-12 at 12 57 07 PM](https://user-images.githubusercontent.com/10292865/129242486-4551d9df-ad5a-4f64-9a29-0b6eb794d44a.png)

`fanout-ingress.yaml` ✅ 

![Screen Shot 2021-08-12 at 1 16 14 PM](https://user-images.githubusercontent.com/10292865/129242496-8e949aea-5d1a-44d2-83d9-c5a87190ec5d.png)
