### PR TITLE
Use networking.k8s.io/v1 for hello-app Ingresses

### DIFF
--- a/hello-app-tls/manifests/helloweb-ingress-tls.yaml
+++ b/hello-app-tls/manifests/helloweb-ingress-tls.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: helloweb
@@ -9,9 +9,11 @@ metadata:
 spec:
   tls:
     - secretName: yourdomain-tls
-  backend:
-    serviceName: helloweb-backend
-    servicePort: 443
+  defaultBackend:
+    service:
+      name: helloweb-backend
+      port:
+        number: 443
 ---
 apiVersion: v1
 kind: Service

--- a/hello-app/manifests/helloweb-ingress-static-ip.yaml
+++ b/hello-app/manifests/helloweb-ingress-static-ip.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # [START container_helloapp_ingress]
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: helloweb
@@ -22,9 +22,11 @@ metadata:
   labels:
     app: hello
 spec:
-  backend:
-    serviceName: helloweb-backend
-    servicePort: 8080
+  defaultBackend:
+    service:
+      name: helloweb-backend
+      port:
+        number: 8080
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
**Background**
* See "Background" section of https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/pull/203.

**Summary of Changes**
* We now use `apiVersion: networking.k8s.io/v1` for Ingresses, in 2 different manifests.
* Manifest fields have been updated to [match the `networking.k8s.io/v1` spec](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122) (e.g., `servicePort` is now `service.port.number`).

**Manual Testing**
I have tested these changes manually. And they work! ✅ 
* [x] Test `helloweb-ingress-static-ip.yaml` via [Configuring domain names with static IP addresses](https://cloud.google.com/kubernetes-engine/docs/tutorials/configuring-domain-name-static-ip.html)
<img width="1167" alt="Screen Shot 2021-08-15 at 6 20 48 PM" src="https://user-images.githubusercontent.com/10292865/129573168-6e4df0b9-17c8-4028-b341-aa66395d8617.png">


* [x]  Test `helloweb-ingress-tls.yaml` via [README.md](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/tree/34dd396bd336c38001117520ce1bab7606ef79e5/hello-app-tls)
<img width="1223" alt="Screen Shot 2021-08-15 at 8 43 05 PM" src="https://user-images.githubusercontent.com/10292865/129573317-cf761c42-4a03-408e-a9c3-13799a183543.png">
