### PR TITLE
Bump gke-windows-builder version to 2.6.1

### DIFF
--- a/windows-multi-arch/cloudbuild.yaml
+++ b/windows-multi-arch/cloudbuild.yaml
@@ -15,7 +15,7 @@
 # [START container_windows_multi_arch_cloudbuild]
 timeout: 3600s
 steps:
-- name: 'gcr.io/gke-release/gke-windows-builder:release-2.6.0-gke.0'
+- name: 'gcr.io/gke-release/gke-windows-builder:release-2.6.1-gke.0'
   args:
   - --container-image-name
   - 'gcr.io/$PROJECT_ID/multiarch-helloworld:latest'


### PR DESCRIPTION
Fixes from version 2.6.0 -> 2.6.1:

- Update the go modules. 