### PR TITLE
Replace use of GCR with AR for migrating-node-pool

### DIFF
--- a/migrating-node-pool/node-pools-deployment.yaml
+++ b/migrating-node-pool/node-pools-deployment.yaml
@@ -14,4 +14,4 @@ spec:
     spec:
       containers:
       - name: hello-app
-        image: gcr.io/google-samples/hello-app:1.0
+        image: us-docker.pkg.dev/google-samples/containers/gke/hello-app:1.0


### PR DESCRIPTION
Please see https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/issues/209.

I have manually tested the relevant tutorial, [Migrating workloads to different machine types](https://cloud.google.com/kubernetes-engine/docs/tutorials/migrating-node-pool), and it works!