### PR TITLE
NodeName from Downward API

### DIFF
--- a/whereami/README.md
+++ b/whereami/README.md
@@ -11,7 +11,7 @@
 `whereami` is a single-container app, designed and packaged to run on Kubernetes. In its simplest form it can be deployed in a single line with only a few parameters.
 
 ```bash
-$ kubectl run --image=gcr.io/google-samples/whereami:v1.2.1 --expose --port 8080 whereami
+$ kubectl run --image=gcr.io/google-samples/whereami:v1.2.2 --expose --port 8080 whereami
 ```
 
 The `whereami`  pod listens on port `8080` and returns a very simple JSON response that indicates who is responding and where they live. This example assumes you're executing the `curl` command from a pod in the same K8s cluster & namespace (although the following examples show how to access from external clients):
@@ -96,7 +96,7 @@ spec:
       serviceAccountName: whereami-ksa
       containers:
       - name: whereami
-        image: gcr.io/google-samples/whereami:v1.2.1
+        image: gcr.io/google-samples/whereami:v1.2.2
         ports:
           - name: http
             containerPort: 8080 #The application is listening on port 8080
@@ -116,6 +116,10 @@ spec:
           initialDelaySeconds: 5
           timeoutSeconds: 1
         env:
+          - name: NODE_NAME #The node name the pod is running on
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
           - name: POD_NAMESPACE #The kubernetes Namespace where the Pod is running
             valueFrom:
               fieldRef:

--- a/whereami/cloudbuild.yaml
+++ b/whereami/cloudbuild.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # This file and other cloudbuild.yaml files are used to ensure that
-# our public Docker images such as us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.1
+# our public Docker images such as us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.2
 # are rebuilt and updated upon changes to the repository.
 
 steps:
@@ -21,12 +21,12 @@ steps:
   args:
     - 'build'
     - '-t'
-    - 'gcr.io/google-samples/whereami:v1.2.1'
+    - 'gcr.io/google-samples/whereami:v1.2.2'
     - '-t'
-    - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.1'
+    - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.2'
     - '.'
   dir: 'whereami'
 
 images:
-  - 'gcr.io/google-samples/whereami:v1.2.1'
-  - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.1'
+  - 'gcr.io/google-samples/whereami:v1.2.2'
+  - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.2'

--- a/whereami/k8s-grpc/deployment.yaml
+++ b/whereami/k8s-grpc/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: whereami-grpc-ksa
       containers:
       - name: whereami-grpc
-        image: gcr.io/google-samples/whereami:v1.2.1
+        image: gcr.io/google-samples/whereami:v1.2.2
         ports:
           - name: grpc
             containerPort: 9090
@@ -29,6 +29,10 @@ spec:
             command: ["/bin/grpc_health_probe", "-addr=:9090"]
           initialDelaySeconds: 10
         env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
           - name: POD_NAMESPACE
             valueFrom:
               fieldRef:

--- a/whereami/k8s/deployment.yaml
+++ b/whereami/k8s/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: whereami-ksa
       containers:
       - name: whereami
-        image: gcr.io/google-samples/whereami:v1.2.1
+        image: gcr.io/google-samples/whereami:v1.2.2
         ports:
           - name: http
             containerPort: 8080
@@ -36,6 +36,10 @@ spec:
           initialDelaySeconds: 5
           timeoutSeconds: 1
         env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
           - name: POD_NAMESPACE
             valueFrom:
               fieldRef:

--- a/whereami/whereami_payload.py
+++ b/whereami/whereami_payload.py
@@ -25,7 +25,7 @@ class WhereamiPayload(object):
 
     def build_payload(self, request_headers):
 
-        # header propagation for HTTP calls to downstream services
+        # header propagation for HTTP calls to downward services
         def getForwardHeaders(request_headers):
             headers = {}
             incoming_headers = ['x-request-id',
@@ -67,7 +67,8 @@ class WhereamiPayload(object):
 
             logging.warning("Unable to capture zone.")
 
-        # get GKE node name
+        # get GKE node name - NOTE: switching to downward API
+        '''
         try:
             r = requests.get(METADATA_URL + 'instance/hostname',
                              headers=METADATA_HEADERS)
@@ -75,6 +76,13 @@ class WhereamiPayload(object):
                 self.payload['node_name'] = str(r.text)
         except:
 
+            logging.warning("Unable to capture node name.")
+        '''
+
+        # get node name via downward API
+        if os.getenv('NODE_NAME'):
+            self.payload['node_name'] = os.getenv('NODE_NAME')
+        else:
             logging.warning("Unable to capture node name.")
 
         # get GKE cluster name
@@ -100,7 +108,7 @@ class WhereamiPayload(object):
         self.payload['timestamp'] = datetime.now().replace(
             microsecond=0).isoformat()
 
-        # get namespace, pod ip, and pod service account via downstream API
+        # get namespace, pod ip, and pod service account via downward API
         if os.getenv('POD_NAMESPACE'):
             self.payload['pod_namespace'] = os.getenv('POD_NAMESPACE')
         else:


### PR DESCRIPTION
related to the discussion in https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/issues/207 moving the node name data source to downward API instead of pulling from GCE metadata server. 