### PR TITLE
Use AR, not GCR, for Windows Multi Arch Tutorial

### DIFF
--- a/windows-multi-arch/cloudbuild.yaml
+++ b/windows-multi-arch/cloudbuild.yaml
@@ -18,5 +18,7 @@ steps:
 - name: 'gcr.io/gke-release/gke-windows-builder:release-2.6.1-gke.0'
   args:
   - --container-image-name
-  - 'gcr.io/$PROJECT_ID/multiarch-helloworld:latest'
+  # Replace <REGISTRY_REGION> and <REPOSITORY>.
+  - '<REGISTRY_REGION>-docker.pkg.dev/$PROJECT_ID/<REPOSITORY>/multiarch-helloworld:latest'
 # [END container_windows_multi_arch_cloudbuild]
+


### PR DESCRIPTION
**Background**
* See Google-internal changes: [cl/404826265](http://cl/404826265)
* This change is for the following GKE tutorial: [Building Windows Server multi-arch images](https://cloud.devsite.corp.google.com/kubernetes-engine/docs/tutorials/building-windows-multi-arch-images).
* The `cloudbuild.yaml` sample code used in that tutorial currently assumes that the user/reader will be using a Container Registry repository. But we want to encourage users/readers to use Artifact Registry instead. 
* GCR Docker image URLs looks like: `gcr.io/my-project/my-image:1.0`
* AR Docker image URLs look like: `us-central1-docker.pkg.dev/my-project/my-repository/my-image:1.0`
* Unlike GCR, AR requires you to select a region (e.g., `us-central1`) and a repository name (e.g., `my-repository`).

**Change Summary**
* We are updating the line in `cloudbuild.yaml` containing the user/reader's Docker image URL to match the format of an Artifact Registry-hosted Docker image URL.

**Additional Notes**
*  This `cloudbuild.yaml` (to be run by [Cloud Build](https://cloud.google.com/build)) is just a single step that runs the following container: `gcr.io/gke-release/gke-windows-builder:release-2.6.1-gke.0`.
    * This is hosted on Container Registry (`gcr.io`). Moving this to Artifact Registry will be done later — likely by the [GKE Windows Multi Arch team](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/master/CODEOWNERS#L9). 