### PR TITLE
Use Artifact Registry for pubsub-sample

### DIFF
--- a/cloud-pubsub/README.md
+++ b/cloud-pubsub/README.md
@@ -10,4 +10,4 @@ This program reads messages published on a particular topic and prints them on
 standard output.
 
 Docker image for this application is available at
-`gcr.io/google-samples/pubsub-sample:v1`.
+`us-docker.pkg.dev/google-samples/containers/gke/pubsub-sample:v1`.

--- a/cloud-pubsub/deployment/pubsub-with-secret.yaml
+++ b/cloud-pubsub/deployment/pubsub-with-secret.yaml
@@ -32,7 +32,7 @@ spec:
           secretName: pubsub-key
       containers:
       - name: subscriber
-        image: gcr.io/google-samples/pubsub-sample:v1
+        image: us-docker.pkg.dev/google-samples/containers/gke/pubsub-sample:v1
         volumeMounts:
         - name: google-cloud-key
           mountPath: /var/secrets/google

--- a/cloud-pubsub/deployment/pubsub.yaml
+++ b/cloud-pubsub/deployment/pubsub.yaml
@@ -28,5 +28,5 @@ spec:
     spec:
       containers:
       - name: subscriber
-        image: gcr.io/google-samples/pubsub-sample:v1
+        image: us-docker.pkg.dev/google-samples/containers/gke/pubsub-sample:v1
 # [END container_pubsub_deployment]


### PR DESCRIPTION
## Background

* Please see https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/issues/209.
* AR = Artifact Registry
* GCR = Google Container Registry

## Change Summary
* This pull-request for `pubsub-sample:v1`:
* I'm replacing instances of the image's GCR URL with the equivalent AR URL.
  * `gcr.io/google-samples/pubsub-sample:v1` → `us-docker.pkg.dev/google-samples/containers/gke/pubsub-sample:v1`

## Tutorials To Update
This pull-request updates `.yaml` files used by:
* [Authenticating to Google Cloud with service accounts](https://cloud.google.com/kubernetes-engine/docs/tutorials/authenticating-to-cloud-platform)
* [Autoscaling Deployments with Cloud Monitoring metrics](https://cloud.google.com/kubernetes-engine/docs/tutorials/autoscaling-metrics#pubsub)

So once merged, I would have to update the above tutorial via [this Google-internal content publisher](https://devsite.corp.google.com/publisher).

## Manually Tested 👍
We can verify that the AR (replacement) image and GCR (replaced) image are equivalent like so:
1. Pull the 2 images you want to compare:
```
docker image pull gcr.io/google-samples/pubsub-sample:v1
docker image pull us-docker.pkg.dev/google-samples/containers/gke/pubsub-sample:v1
```
2.  Inspecting both images:
```
docker image inspect gcr.io/google-samples/pubsub-sample:v1
docker image inspect us-docker.pkg.dev/google-samples/containers/gke/pubsub-sample:v1
```
3. See that the [RootFS values match](https://stackoverflow.com/questions/46321878/how-to-verify-if-the-content-of-two-docker-images-is-exactly-the-same/46322160#46322160).