### PR TITLE
Revert "Use AR, not GCR, for Windows Multi Arch Tutorial"

### DIFF
--- a/windows-multi-arch/cloudbuild.yaml
+++ b/windows-multi-arch/cloudbuild.yaml
@@ -18,7 +18,5 @@ steps:
 - name: 'gcr.io/gke-release/gke-windows-builder:release-2.6.1-gke.0'
   args:
   - --container-image-name
-  # Replace <REGISTRY_REGION> and <REPOSITORY>.
-  - '<REGISTRY_REGION>-docker.pkg.dev/$PROJECT_ID/<REPOSITORY>/multiarch-helloworld:latest'
+  - 'gcr.io/$PROJECT_ID/multiarch-helloworld:latest'
 # [END container_windows_multi_arch_cloudbuild]
-


### PR DESCRIPTION
- See associated Google-internal CL: [cl/405872146](https://critique-ng.corp.google.com/cl/405872146)
- This pull-request reverts #216.
- Reason for reverting: 
  - See comments in [cl/405718868](https://critique-ng.corp.google.com/cl/405718868).
  - Basically, the use of Artifact Registry in the [Building Windows Server multi-arch images](https://cloud.google.com/kubernetes-engine/docs/tutorials/building-windows-multi-arch-images) tutorial leads to error.
- I will look into resolving the above error, and redo the changes.