### PR TITLE
Update to use official cloud builders and AR urls

### DIFF
--- a/windows-multi-arch/cloudbuild.yaml
+++ b/windows-multi-arch/cloudbuild.yaml
@@ -15,8 +15,8 @@
 # [START container_windows_multi_arch_cloudbuild]
 timeout: 3600s
 steps:
-- name: 'gcr.io/gke-release/gke-windows-builder:release-2.6.1-gke.0'
+- name: 'us-docker.pkg.dev/cloud-builders/preview/gke-windows-builder:latest'
   args:
   - --container-image-name
-  - 'gcr.io/$PROJECT_ID/multiarch-helloworld:latest'
+  - 'us-docker.pkg.dev/$PROJECT_ID/docker-repo/multiarch-helloworld:latest'
 # [END container_windows_multi_arch_cloudbuild]


### PR DESCRIPTION
Once the https://github.com/bendory/cloud-builders/pull/7 gets merged, will update the gke-windows-builder to use official cloud builders.