### PR TITLE
Specified python3.8-slim image in Dockerfile

### DIFF
--- a/cloud-pubsub/Dockerfile
+++ b/cloud-pubsub/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-slim
+FROM python:3.8-slim
 COPY . .
 RUN pip install -r requirements.txt
 ENTRYPOINT ["python", "-u", "main.py"]


### PR DESCRIPTION
This addresses [this issue](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/issues/224), where  a breaking change was introduced in Python 3.10.