### PR TITLE
Use Artifact Registry for hello-app-redis:1.0

### DIFF
--- a/hello-app-redis/manifests/app-deployment.yaml
+++ b/hello-app-redis/manifests/app-deployment.yaml
@@ -43,7 +43,7 @@ spec:
             topologyKey: kubernetes.io/hostname
       # Pod anti affinity config END
       containers:
-      - image: gcr.io/google-samples/hello-app-redis:1.0  # change to the image name you built
+      - image: us-docker.pkg.dev/google-samples/containers/gke/hello-app-redis:1.0  # change to the image name you built
         name: hello-app
         # Readiness probe config START
         readinessProbe:


### PR DESCRIPTION
## Background

* Please see https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/issues/209.
* AR = Artifact Registry
* GCR = Google Container Registry

## Change Summary
* This pull-request for `hello-app-redis:1.0`.
* I'm replacing instances of the image's GCR URL with the equivalent AR URL.
  * `gcr.io/google-samples/hello-app-redis:1.0` → `us-docker.pkg.dev/google-samples/containers/gke/hello-app-redis:1.0`

## Tutorials To Update
This pull-request updates `.yaml` files used by:
* [Upgrading a GKE cluster running a stateful workload](https://cloud.google.com/kubernetes-engine/docs/tutorials/upgrading-stateful-workload)

So once this pull-request is merged, I will be submitting [cl/412118908](https://critique.corp.google.com/cl/412118908).

## Manually Tested 👍
We can verify that the AR (replacement) image and GCR (replaced) image are equivalent like so:
1. Pull the 2 images you want to compare:
```
docker image pull gcr.io/google-samples/hello-app-redis:1.0
docker image pull us-docker.pkg.dev/google-samples/containers/gke/hello-app-redis:1.0
```
2.  Inspecting both images:
```
docker image inspect gcr.io/google-samples/hello-app-redis:1.0
docker image inspect us-docker.pkg.dev/google-samples/containers/gke/hello-app-redis:1.0
```
3. See that the [RootFS values match](https://stackoverflow.com/questions/46321878/how-to-verify-if-the-content-of-two-docker-images-is-exactly-the-same/46322160#46322160).