### PR TITLE
Use AR, not GCR, for hello-app-tls

### DIFF
--- a/hello-app-tls/README.md
+++ b/hello-app-tls/README.md
@@ -8,7 +8,7 @@ HTTPS queries on port `8443`:
 - TLS cert and key files are configured through environment variables `TLS_CERT`
   and `TLS_KEY`.
 - The application image is available at
-  `gcr.io/google-samples/hello-app-tls:1.0`.
+  `us-docker.pkg.dev/google-samples/containers/gke/hello-app-tls:1.0`.
 
 This example uses `Ingress` (Cloud HTTPS Load Balancer) to terminate HTTPS
 connections (with a provided certificate).

--- a/hello-app-tls/manifests/helloweb-deployment.yaml
+++ b/hello-app-tls/manifests/helloweb-deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: hello-app
-        image: gcr.io/google-samples/hello-app-tls:1.0
+        image: us-docker.pkg.dev/google-samples/containers/gke/hello-app-tls:1.0
         imagePullPolicy: Always
         ports:
         - containerPort: 8443


### PR DESCRIPTION
## Background

* Please see https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/issues/209.
* AR = Artifact Registry
* GCR = Google Container Registry

## Change Summary
* This pull-request for `hello-app-tls:1.0`.
* I'm replacing instances of the image's GCR URL with the equivalent AR URL.
  * `gcr.io/google-samples/hello-app-tls:1.0` → `us-docker.pkg.dev/google-samples/containers/gke/hello-app-tls:1.0`

## Tutorials To Update
* This sample image is not used in any of our cloud.google.com tutorials.
* It is only used in this [README.md](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/tree/2e6eac9edc47dd6ce4a614c46826525c85318d8a/hello-app-tls).

## Manually Tested 👍
* I have manually gone through the relevant [README.md](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/tree/2e6eac9edc47dd6ce4a614c46826525c85318d8a/hello-app-tls) using my own cluster, and everything works as expected.

![Screen Shot 2021-11-26 at 12 54 06 PM](https://user-images.githubusercontent.com/10292865/143617543-12c8659a-9077-4d49-bcff-44a569a99429.png)

