### PR TITLE
Update year of hello-app/main.go

### DIFF
--- a/hello-app/main.go
+++ b/hello-app/main.go
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 Google Inc.
+ * Copyright 2021 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
* The "default" branch of this repository was just changed to `main`: https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/pull/229
* I just updated the Cloud Build Triggers used by the repository to use the branch `main` — instead of `master`.
* This pull-request was created primarily to test that the Cloud Build Triggers still work.
* Merging this pull-request should run the Cloud Build Trigger associated with the `hello-app:1.0` images and `hello-app:2.0` images.