### PR TITLE
Renovate bot edit to ignore dockerfiles

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,8 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "dockerfile": {
+    "enabled": false
+  }
 }


### PR DESCRIPTION
To avoid triggering our Dockerfiles (before we can update them and thoroughly test images with their dependencies), we will for the time being have renovate bot skip our Dockerfiles
 
Using the renovatebot docs ([Supported managers](https://docs.renovatebot.com/modules/manager/#supported-managers), and [disabling the managers](https://docs.renovatebot.com/modules/manager/#ignoring-files-that-match-the-default-filematch))