### PR TITLE
Use AR instead of GCR for whereami

### DIFF
--- a/whereami/k8s-grpc/deployment.yaml
+++ b/whereami/k8s-grpc/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: whereami-grpc-ksa
       containers:
       - name: whereami-grpc
-        image: gcr.io/google-samples/whereami:v1.2.6
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.6
         ports:
           - name: grpc
             containerPort: 9090

--- a/whereami/k8s/deployment.yaml
+++ b/whereami/k8s/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: whereami-ksa
       containers:
       - name: whereami
-        image: gcr.io/google-samples/whereami:v1.2.6
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.6
         ports:
           - name: http
             containerPort: 8080


### PR DESCRIPTION
* Please see [Use AR instead of GCR for Deployments #209](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/issues/209).

    * AR = Artifact Registry

    * GCR = Google Container Registry

    * This pull-request for `whereami:v1.2.6`:

    * I'm replacing instances of the images' GCR URLs with the equivalent AR URLs.

      * `gcr.io/google-samples/whereami:v1.2.6` → `us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.6`

So once merged, I would have to update the above tutorials via [this Google-internal content publisher](https://devsite.corp.google.com/publisher).

We can verify that the AR (replacement) images and GCR (replaced) images are equivalent like so:

    1. Pull the 2 images you want to compare:

```
docker image pull gcr.io/google-samples/whereami:v1.2.6
docker image pull us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.6
```

    2. Inspecting both images:

```
docker image inspect gcr.io/google-samples/whereami:v1.2.6
docker image inspect us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.6
```

    3. See that the [RootFS values match](https://stackoverflow.com/questions/46321878/how-to-verify-if-the-content-of-two-docker-images-is-exactly-the-same/46322160#46322160).