### PR TITLE
Use AR — not GCR — in README.md files

### DIFF
--- a/hello-app-cdn/README.md
+++ b/hello-app-cdn/README.md
@@ -10,4 +10,4 @@ It responds to requests with the `Cache-Control` HTTP header to ensure the respo
 are cached.
 
 The container image for this directory is publicly available at
-`gcr.io/google-samples/hello-app-cdn:1.0`.
+`us-docker.pkg.dev/google-samples/containers/gke/hello-app-cdn:1.0`.

--- a/hello-app-redis/README.md
+++ b/hello-app-redis/README.md
@@ -10,5 +10,5 @@ This directory contains:
 - `main.go` The HTTP server uses Redis as a cache database, counts the number of requests it receives, and prints out the number on the website. If the Redis service works, the number should keep increasing.
 - `Dockerfile` is used to build the Docker image for the application.
 
-The container image for this directory is publicly available at `gcr.io/google-samples/hello-app-redis:1.0`
+The container image for this directory is publicly available at `us-docker.pkg.dev/google-samples/containers/gke/hello-app-redis:1.0`
 

--- a/whereami/README.md
+++ b/whereami/README.md
@@ -19,7 +19,7 @@ Prometheus metrics are exposed from `whereami` at `x.x.x.x/metrics` in both Flas
 `whereami` is a single-container app, designed and packaged to run on Kubernetes. In its simplest form it can be deployed in a single line with only a few parameters.
 
 ```bash
-$ kubectl run --image=gcr.io/google-samples/whereami:v1.2.6 --expose --port 8080 whereami
+$ kubectl run --image=us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.6 --expose --port 8080 whereami
 ```
 
 The `whereami`  pod listens on port `8080` and returns a very simple JSON response that indicates who is responding and where they live. This example assumes you're executing the `curl` command from a pod in the same K8s cluster & namespace (although the following examples show how to access from external clients):
@@ -104,7 +104,7 @@ spec:
       serviceAccountName: whereami-ksa
       containers:
       - name: whereami
-        image: gcr.io/google-samples/whereami:v1.2.6
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.6
         ports:
           - name: http
             containerPort: 8080 #The application is listening on port 8080


### PR DESCRIPTION
## Background
* AR = Artifact Registry
* GCR = Google Container Registry
* In https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/issues/209, we replaced all instances of GCR (inside Kubernetes manifests) with AR.

## Change Summary
In this pull-request:
* we're replacing all instance of GCR samples with AR samples inside `README.md` files.

## How to Review
1. Make sure the URLs are correctly replaced.
2. `Ctrl/Command` + `Shift` + `F` and search `gcr.io/google-samples` in Visual Studio (ignore `cloudbuild.yaml` files). Make sure I haven't missed anything.