### PR TITLE
Update Windows cloudbuild config

### DIFF
--- a/windows-multi-arch/cloudbuild.yaml
+++ b/windows-multi-arch/cloudbuild.yaml
@@ -15,8 +15,9 @@
 # [START container_windows_multi_arch_cloudbuild]
 timeout: 3600s
 steps:
-- name: 'us-docker.pkg.dev/cloud-builders/preview/gke-windows-builder:latest'
+- name: 'us-docker.pkg.dev/gke-windows-tools/docker-repo/gke-windows-builder:latest'
   args:
   - --container-image-name
-  - 'us-docker.pkg.dev/$PROJECT_ID/docker-repo/multiarch-helloworld:latest'
+  # Replace <REGISTRY_REGION> and <REPOSITORY>.
+  - '<REGISTRY_REGION>-docker.pkg.dev/$PROJECT_ID/<REPOSITORY>/multiarch-helloworld:latest'
 # [END container_windows_multi_arch_cloudbuild]


### PR DESCRIPTION
This sample needs to pull the builder from a different artifact registry location. 

Also, follows up on https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/pull/222: we do not want to hard-code the region name or location in this file, the user should fill them in.

This PR aligns with https://cloud.google.com/kubernetes-engine/docs/tutorials/building-windows-multi-arch-images (and the changes I'm making to it in internal change 425411666).