### PR TITLE
Fix GKE Windows CODEOWNERS again

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,4 +6,4 @@
 *                   @GoogleCloudPlatform/anthos-dpe
 
 # Directory-specific owners
-/windows-multi-arch/ @ibabou @liurupeng @mcshooter @pjh
+/windows-multi-arch/ @ibabou @pjh


### PR DESCRIPTION
For some reason on https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/pull/271 GitHub is only detecting mcshooter as a code owner, and not ibabou. The owners detection on files for this subdirectory seems to be incomplete:
![image](https://user-images.githubusercontent.com/280787/152023464-0f782de6-43ef-4e28-894c-50791fa45c49.png)


Michelle is on leave and can't approve that PR, so I'm trying to fix the CODEOWNERS by removing mcshooter and liurupeng. liurupeng is on the team but is not a GoogleCloudPlatform org member yet, so perhaps that's tripping up the GitHub owners detection somehow. I don't see any other good reason why ibabou would not have owner approval power with the current file.