### PR TITLE
Renovate bot config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
   },
   "pip-compile": {
     "enabled": true,
+    "includePaths":["batch/aiml-workloads/**"],
     "fileMatch": ["(^|/)requirements\\.in$"],
     "lockFileMaintenance": {
       "enabled": true

--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,33 @@
   ],
   "dockerfile": {
     "enabled": false
+  },
+  "pip-compile": {
+    "enabled": true,
+    "fileMatch": ["(^|/)requirements\\.in$"],
+    "lockFileMaintenance": {
+      "enabled": true
+    }
+  },
+  "prConcurrentLimit":5,
+  "stabilityDays":7,
+  "vulnerabilityAlerts":{
+     "labels":[
+       "type:security" 
+     ],
+     "stabilityDays":0
+  },
+  "labels": ["dependencies"],
+  "python":{
+    "addLabels": ["lang: python"]
+  },
+  "java":{
+    "addLabels": ["lang: java"]
+  },
+  "golang":{
+    "addLabels": ["lang: go"]
+  },
+  "nuget":{
+    "addLabels": ["lang: dotnet"]
   }
 }


### PR DESCRIPTION
I see that the batch workloads sample added into this repo use pip-compile tools. 

To avoid renovate bot from opening PRs to update `requirements.txt` instead of `requirements.in`, the [includePaths](https://docs.renovatebot.com/configuration-options/#includepaths) will hopefully only enable the pip compile behavior in that folder 

Once merged, hopefully the PRs will close