### PR TITLE
Whereami app: `grpc-health-probe`:v0.4.11 / `curl`:v7.83.1 / `python`:3.10-slim

### DIFF
--- a/.github/workflows/whereami-ci.yml
+++ b/.github/workflows/whereami-ci.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
     paths:
-      - .github/workflows/whereami-ci.yml
+      - '.github/workflows/whereami-ci.yml'
       - 'whereami/**'
   pull_request:
 jobs:
@@ -15,4 +15,4 @@ jobs:
       - name: build whereami container
         run: |
           cd whereami
-          docker build --tag ${IMAGE_NAME} .
+          docker build --tag whereami .

--- a/.github/workflows/whereami-ci.yml
+++ b/.github/workflows/whereami-ci.yml
@@ -1,0 +1,18 @@
+name: ci
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/whereami-ci.yml
+      - 'whereami/**'
+  pull_request:
+jobs:
+  job:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: build whereami container
+        run: |
+          cd whereami
+          docker build --tag ${IMAGE_NAME} .

--- a/.github/workflows/whereami-ci.yml
+++ b/.github/workflows/whereami-ci.yml
@@ -1,4 +1,4 @@
-name: ci
+name: whereami-ci
 on:
   push:
     branches:

--- a/whereami/Dockerfile
+++ b/whereami/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim
+FROM python:3.10-slim
 
 #MAINTAINER Alex Mattson "alex.mattson@gmail.com"
 
@@ -6,9 +6,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   wget && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* && \
-  wget -O /bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.7/grpc_health_probe-linux-amd64 && \ 
+  wget -O /bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.11/grpc_health_probe-linux-amd64 && \ 
   chmod +x /bin/grpc_health_probe && \
-  wget -O /bin/curl https://github.com/moparisthebest/static-curl/releases/download/v7.81.0/curl-amd64 && \ 
+  wget -O /bin/curl https://github.com/moparisthebest/static-curl/releases/download/v7.83.1/curl-amd64 && \ 
   chmod +x /bin/curl
 COPY ./requirements.txt /app/requirements.txt
 

--- a/whereami/README.md
+++ b/whereami/README.md
@@ -104,7 +104,7 @@ spec:
       serviceAccountName: whereami-ksa
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.8
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.9
         ports:
           - name: http
             containerPort: 8080 #The application is listening on port 8080

--- a/whereami/README.md
+++ b/whereami/README.md
@@ -19,7 +19,7 @@ Prometheus metrics are exposed from `whereami` at `x.x.x.x/metrics` in both Flas
 `whereami` is a single-container app, designed and packaged to run on Kubernetes. In its simplest form it can be deployed in a single line with only a few parameters.
 
 ```bash
-$ kubectl run --image=us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.8 --expose --port 8080 whereami
+$ kubectl run --image=us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.9 --expose --port 8080 whereami
 ```
 
 The `whereami`  pod listens on port `8080` and returns a very simple JSON response that indicates who is responding and where they live. This example assumes you're executing the `curl` command from a pod in the same K8s cluster & namespace (although the following examples show how to access from external clients):

--- a/whereami/cloudbuild.yaml
+++ b/whereami/cloudbuild.yaml
@@ -21,12 +21,12 @@ steps:
   args:
     - 'build'
     - '-t'
-    - 'gcr.io/google-samples/whereami:v1.2.8'
+    - 'gcr.io/google-samples/whereami:v1.2.9'
     - '-t'
-    - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.8'
+    - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.9'
     - '.'
   dir: 'whereami'
 
 images:
-  - 'gcr.io/google-samples/whereami:v1.2.8'
-  - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.8'
+  - 'gcr.io/google-samples/whereami:v1.2.9'
+  - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.9'

--- a/whereami/k8s-grpc/deployment.yaml
+++ b/whereami/k8s-grpc/deployment.yaml
@@ -32,7 +32,7 @@ spec:
       serviceAccountName: whereami-grpc-ksa
       containers:
       - name: whereami-grpc
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.8
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.9
         ports:
           - name: grpc
             containerPort: 9090

--- a/whereami/k8s/deployment.yaml
+++ b/whereami/k8s/deployment.yaml
@@ -32,7 +32,7 @@ spec:
       serviceAccountName: whereami-ksa
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.8
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.9
         ports:
           - name: http
             containerPort: 8080


### PR DESCRIPTION
New version: `whereami:v1.2.9`

Update Whereami app's dependencies:
- [`grpc-health-probe`: v0.4.11](https://github.com/grpc-ecosystem/grpc-health-probe/releases/tag/v0.4.11)
- `curl`: v7.83.1
- `python`: 3.10-slim

It's getting rid of the following CVEs:
- CVE-2022-1292 - Critical - 10
- CVE-2022-1664 - High - 7.5
- CVE-2018-25032 - Medium - 5
- CVE-2022-1271

I also took the opportunity to add a quick CI (`docker build` in GitHub actions) for the `whereami` app in order to get rapid feedback if building the container image is failing or not, at least. This part is not to replace the Cloud Build setup in place once merged in `main` to push the new image, it's just for a quick CI against PR opened for the `whereami` in order to get direct/quick feedback.

- [X] Tested on my own GKE cluster