### PR TITLE
adding `theemadnes` as the owner of the `whereami` folder

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,3 +7,4 @@
 
 # Directory-specific owners
 /windows-multi-arch/ @ibabou @liurupeng @mcshooter @pjh
+/whereami/ @theemadnes


### PR DESCRIPTION
In order to get the creator and owner of the `whereami` app the ability to LGTM on PRs associated to this app