### PR TITLE
Fix redis version in hello-app-redis example

### DIFF
--- a/hello-app-redis/manifests/redis-cluster.yaml
+++ b/hello-app-redis/manifests/redis-cluster.yaml
@@ -57,7 +57,7 @@ spec:
             cpu: "100m"
             memory: "100Mi"
         ports:
-            - name: redis
+            - name: redis:6.2
               containerPort: 6379
               protocol: "TCP"
             - name: cluster


### PR DESCRIPTION
Following the codelab https://cloud.google.com/kubernetes-engine/docs/tutorials/upgrading-stateful-workload today yields an error: 
```
500 - Error due to redis cluster broken!
got 4 elements in cluster info address, expected 2 or 3
```

This seems to be because redis version 7 was released April of this year and is currently incompatible with go-redis. See 
https://github.com/go-redis/redis/issues/2085 .

For now, we should fix redis in the codelab at 6.2 for it to continue working. Once a stable go-redis is released (v9 currently in beta -- https://github.com/go-redis/redis/tree/v9.0.0-beta.1), we can fix this to v7 instead, rebuild the image used in the app-deployment to the latest go-redis version as an alternative fix.