### PR TITLE
Fix redis image version and port name

### DIFF
--- a/hello-app-redis/manifests/redis-cluster.yaml
+++ b/hello-app-redis/manifests/redis-cluster.yaml
@@ -45,7 +45,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: redis
-        image: "redis"
+        image: "redis:6.2"
         command:
           - "redis-server"
         args:
@@ -57,7 +57,7 @@ spec:
             cpu: "100m"
             memory: "100Mi"
         ports:
-            - name: redis:6.2
+            - name: redis
               containerPort: 6379
               protocol: "TCP"
             - name: cluster


### PR DESCRIPTION
The image version was placed in the port name field rather than the container image field. This moves it to the correct location. Verified locally.