### PR TITLE
Stateful node pool upgrade for "Upgrading a GKE cluster running a stateful workload"

### DIFF
--- a/hello-app-redis/manifests/app-deployment.yaml
+++ b/hello-app-redis/manifests/app-deployment.yaml
@@ -60,4 +60,3 @@ spec:
           timeoutSeconds: 1
 # [END container_helloapp_redis]
 # [END gke_manifests_app_deployment_deployment_hello_web]
----

--- a/hello-app-redis/manifests/pdb-maxunavailable.yaml
+++ b/hello-app-redis/manifests/pdb-maxunavailable.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redis-pdb
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: redis

--- a/hello-app-redis/manifests/pdb-maxunavailable.yaml
+++ b/hello-app-redis/manifests/pdb-maxunavailable.yaml
@@ -1,9 +1,0 @@
-apiVersion: policy/v1
-kind: PodDisruptionBudget
-metadata:
-  name: redis-pdb
-spec:
-  maxUnavailable: 1
-  selector:
-    matchLabels:
-      app: redis

--- a/hello-app-redis/manifests/pdb-minavailable.yaml
+++ b/hello-app-redis/manifests/pdb-minavailable.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redis-pdb
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: redis

--- a/hello-app-redis/manifests/pdb-minavailable.yaml
+++ b/hello-app-redis/manifests/pdb-minavailable.yaml
@@ -3,7 +3,7 @@ kind: PodDisruptionBudget
 metadata:
   name: redis-pdb
 spec:
-  minAvailable: 2
+  minAvailable: 3
   selector:
     matchLabels:
       app: redis

--- a/hello-app-redis/manifests/redis-cluster.yaml
+++ b/hello-app-redis/manifests/redis-cluster.yaml
@@ -19,7 +19,7 @@ kind: StatefulSet
 metadata:
   name: redis
 spec:
-  serviceName: "redis-service"
+  serviceName: "redis-cluster"
   replicas: 6
   selector:
     matchLabels:
@@ -63,6 +63,27 @@ spec:
             - name: cluster
               containerPort: 16379
               protocol: "TCP"
+        startupProbe:
+          periodSeconds: 5
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 20
+          tcpSocket:
+            port: redis
+        livenessProbe:
+          periodSeconds: 5
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+          exec:
+            command: ["sh", "-c", "/probes/liveness.sh"]
+        readinessProbe:
+          periodSeconds: 5
+          timeoutSeconds: 1
+          successThreshold: 1
+          failureThreshold: 5
+          exec:
+            command: ["sh", "-c", "/probes/readiness.sh"]
         volumeMounts:
         - name: conf
           mountPath: /conf
@@ -70,11 +91,18 @@ spec:
         - name: data
           mountPath: /data
           readOnly: false
+        - name: probes
+          mountPath: /probes
+          readOnly: true
       volumes:
       - name: conf
         configMap:
           name: redis-cluster
           defaultMode: 0755
+      - name: probes
+        configMap:
+          name: redis-probes
+          defaultMode: 0555
   volumeClaimTemplates:
   - metadata:
       name: data

--- a/hello-app-redis/manifests/redis-cluster.yaml
+++ b/hello-app-redis/manifests/redis-cluster.yaml
@@ -84,4 +84,3 @@ spec:
         requests:
           storage: 1Gi
 # [END gke_manifests_redis_cluster_statefulset_redis]
----

--- a/hello-app-redis/manifests/redis-cluster.yaml
+++ b/hello-app-redis/manifests/redis-cluster.yaml
@@ -63,6 +63,7 @@ spec:
             - name: cluster
               containerPort: 16379
               protocol: "TCP"
+        # [START gke_manifests_redis_cluster_statefulset_redis_probes]
         startupProbe:
           periodSeconds: 5
           timeoutSeconds: 5
@@ -84,6 +85,7 @@ spec:
           failureThreshold: 5
           exec:
             command: ["sh", "-c", "/probes/readiness.sh"]
+        # [END gke_manifests_redis_cluster_statefulset_redis_probes]
         volumeMounts:
         - name: conf
           mountPath: /conf

--- a/hello-app-redis/manifests/redis-configmap.yaml
+++ b/hello-app-redis/manifests/redis-configmap.yaml
@@ -33,6 +33,7 @@ kind: ConfigMap
 metadata:
   name: redis-probes
 data:
+# [START gke_manifests_redis_configmap_configmap_redis_cluster_probes]
   readiness.sh: |-
     #!/bin/sh
 
@@ -59,4 +60,5 @@ data:
       echo "$pingResponse"
       exit 1
     fi
+# [END gke_manifests_redis_configmap_configmap_redis_cluster_probes]
 # [END gke_manifests_redis_configmap_configmap_redis_cluster]

--- a/hello-app-redis/manifests/redis-configmap.yaml
+++ b/hello-app-redis/manifests/redis-configmap.yaml
@@ -27,4 +27,36 @@ data:
     protected-mode no
     dir /data
     port 6379
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-probes
+data:
+  readiness.sh: |-
+    #!/bin/sh
+
+    pingResponse="$(redis-cli -h localhost ping)"
+    if [ "$?" -eq "124" ]; then
+      echo "PING timed out"
+      exit 1
+    fi
+
+    if [ "$pingResponse" != "PONG"]; then
+      echo "$pingResponse"
+      exit 1
+    fi
+  liveness.sh: |-
+    #!/bin/sh
+
+    pingResponse="$(redis-cli -h localhost ping | head -n1 | awk '{print $1;}')"
+    if [ "$?" -eq "124" ]; then
+      echo "PING timed out"
+      exit 1
+    fi
+
+    if [ "$pingResponse" != "PONG"] && [ "$pingResponse" != "LOADING" ] && [ "$pingResponse" != "MASTERDOWN" ]; then
+      echo "$pingResponse"
+      exit 1
+    fi
 # [END gke_manifests_redis_configmap_configmap_redis_cluster]

--- a/hello-app-redis/manifests/redis-configmap.yaml
+++ b/hello-app-redis/manifests/redis-configmap.yaml
@@ -28,4 +28,3 @@ data:
     dir /data
     port 6379
 # [END gke_manifests_redis_configmap_configmap_redis_cluster]
----

--- a/hello-app-redis/manifests/redis-service.yaml
+++ b/hello-app-redis/manifests/redis-service.yaml
@@ -31,4 +31,3 @@ spec:
   sessionAffinity: None
   type: ClusterIP
 # [END gke_manifests_redis_service_service_redis_cluster]
----

--- a/hello-app-redis/manifests/roles.sh
+++ b/hello-app-redis/manifests/roles.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Usage: ./roles.sh
 
 urls=$(kubectl get pods -l app=redis -o jsonpath='{range.items[*]}{.status.podIP} ')
 command="kubectl exec -it redis-0 -- redis-cli --cluster create --cluster-replicas 1 "

--- a/hello-app-redis/manifests/roles.sh
+++ b/hello-app-redis/manifests/roles.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+urls=$(kubectl get pods -l app=redis -o jsonpath='{range.items[*]}{.status.podIP} ')
+command="kubectl exec -it redis-0 -- redis-cli --cluster create --cluster-replicas 1 "
+
+for url in $urls
+do
+    command+=$url":6379 "
+done
+
+echo "Executing command: " $command
+$command

--- a/hello-app-redis/scripts/generate_load.sh
+++ b/hello-app-redis/scripts/generate_load.sh
@@ -16,7 +16,7 @@
 # [START gke_scripts_generate_load]
 # [START container_helloapp_redis_generate_load]
 #!/bin/bash
-# Usage: generate_load.sh <IP> <QPS>_
+# Usage: ./generate_load.sh <IP> <QPS>
 
 IP=$1
 QPS=$2


### PR DESCRIPTION
Changes to the tutorial https://cloud.google.com/kubernetes-engine/docs/tutorials/upgrading-stateful-workload to include more best practices on upgrading a stateful node pool. 