### PR TITLE
update dotnet example to version 6

### DIFF
--- a/quickstart/dotnet/Dockerfile
+++ b/quickstart/dotnet/Dockerfile
@@ -1,7 +1,5 @@
 # Use Microsoft's official lightweight .NET images.
-# https://hub.docker.com/r/microsoft/dotnet
-
-FROM mcr.microsoft.com/dotnet/core/sdk:2.2-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /app
 
 # Install production dependencies.
@@ -16,8 +14,9 @@ COPY . ./
 RUN dotnet publish -c Release -o out
 
 # Run the web service on container startup in a lean production image.
-FROM mcr.microsoft.com/dotnet/core/aspnet:2.2-alpine
+FROM mcr.microsoft.com/dotnet/aspnet:6.0
 WORKDIR /app
+COPY --from=build /app/out .
 
-COPY --from=build /app/out ./
-CMD ["dotnet", "HelloGKE.dll"]
+# Start the .dll (will have the same name as your .csproj file)
+ENTRYPOINT ["dotnet", "helloworld-gke.dll"]

--- a/quickstart/dotnet/Program.cs
+++ b/quickstart/dotnet/Program.cs
@@ -12,38 +12,16 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-using System;
-using Microsoft.AspNetCore;
-using Microsoft.AspNetCore.Hosting;
+var builder = WebApplication.CreateBuilder(args);
 
-namespace HelloGKE
-{
-    public class Program
-    {
-        public static void Main(string[] args)
-        {
-            CreateWebHostBuilder(args).Build().Run();
-        }
+// Google Cloud Run sets the PORT environment variable to tell this
+// process which port to listen to.
+var port = Environment.GetEnvironmentVariable("PORT") ?? "8080";
+var url = $"http://0.0.0.0:{port}";
+var target = Environment.GetEnvironmentVariable("TARGET") ?? "World";
 
-        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-            WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>()
-                .UsePortEnvironmentVariable();
-    }
+var app = builder.Build();
 
-    static class ProgramExtensions
-    {
-        // Google Cloud Run sets the PORT environment variable to tell this
-        // process which port to listen to.
-        public static IWebHostBuilder UsePortEnvironmentVariable(
-            this IWebHostBuilder builder)
-        {
-            string port = Environment.GetEnvironmentVariable("PORT");
-            if (!string.IsNullOrEmpty(port))
-            {
-                builder.UseUrls($"http://0.0.0.0:{port}");
-            }
-            return builder;
-        }
-    }
-}
+app.MapGet("/", () => $"Hello {target}!");
+
+app.Run(url);


### PR DESCRIPTION
The existing GKE dotnet Quickstart example is from dotnet 2.2 (will fail in cloud shell), this PR will update the example to dotnet 6 (will work in cloud shell).

> Related, but not critical: This example has a reference to Cloud Run for getting the port, but I don't know if that's necessary for GKE? We may want to simplify the code to always use `8080`?