### PR TITLE
Bump `whereami` to  v1.2.12

### DIFF
--- a/whereami/Dockerfile
+++ b/whereami/Dockerfile
@@ -6,9 +6,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   wget && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* && \
-  wget -O /bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.11/grpc_health_probe-linux-amd64 && \ 
+  wget -O /bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.13/grpc_health_probe-linux-amd64 && \ 
   chmod +x /bin/grpc_health_probe && \
-  wget -O /bin/curl https://github.com/moparisthebest/static-curl/releases/download/v7.83.1/curl-amd64 && \ 
+  wget -O /bin/curl https://github.com/moparisthebest/static-curl/releases/download/v7.85.0/curl-amd64 && \ 
   chmod +x /bin/curl
 COPY ./requirements.txt /app/requirements.txt
 

--- a/whereami/README.md
+++ b/whereami/README.md
@@ -19,7 +19,7 @@ Prometheus metrics are exposed from `whereami` at `x.x.x.x/metrics` in both Flas
 `whereami` is a single-container app, designed and packaged to run on Kubernetes. In its simplest form it can be deployed in a single line with only a few parameters.
 
 ```bash
-$ kubectl run --image=us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.11 --expose --port 8080 whereami
+$ kubectl run --image=us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.12 --expose --port 8080 whereami
 ```
 
 The `whereami`  pod listens on port `8080` and returns a very simple JSON response that indicates who is responding and where they live. This example assumes you're executing the `curl` command from a pod in the same K8s cluster & namespace (although the following examples show how to access from external clients):
@@ -104,7 +104,7 @@ spec:
       serviceAccountName: whereami-ksa
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.11
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.12
         ports:
           - name: http
             containerPort: 8080 #The application is listening on port 8080

--- a/whereami/cloudbuild.yaml
+++ b/whereami/cloudbuild.yaml
@@ -21,12 +21,12 @@ steps:
   args:
     - 'build'
     - '-t'
-    - 'gcr.io/google-samples/whereami:v1.2.11'
+    - 'gcr.io/google-samples/whereami:v1.2.12'
     - '-t'
-    - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.11'
+    - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.12'
     - '.'
   dir: 'whereami'
 
 images:
-  - 'gcr.io/google-samples/whereami:v1.2.11'
-  - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.11'
+  - 'gcr.io/google-samples/whereami:v1.2.12'
+  - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.12'

--- a/whereami/k8s-grpc/deployment.yaml
+++ b/whereami/k8s-grpc/deployment.yaml
@@ -32,7 +32,7 @@ spec:
       serviceAccountName: whereami-grpc-ksa
       containers:
       - name: whereami-grpc
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.11
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.12
         ports:
           - name: grpc
             containerPort: 9090

--- a/whereami/k8s/deployment.yaml
+++ b/whereami/k8s/deployment.yaml
@@ -32,7 +32,7 @@ spec:
       serviceAccountName: whereami-ksa
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.11
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.12
         ports:
           - name: http
             containerPort: 8080


### PR DESCRIPTION
Just rebuilding the image as-is fixed:
- `CVE-2022-40674 	 Critical	9.8	Yes	expat	OS`

Bumping `grpc-health-probe` and `static-curl`, fixed:
- `CVE-2022-30632 | High | 7.5 | Yes | go | Go stdlib`
- `CVE-2022-32189 | High | 7.5 | Yes | go | Go stdlib`
- `CVE-2022-30630 | High | 7.5 | Yes | go | Go stdlib`
- `CVE-2022-30580 | High | 7.8 | Yes | go | Go stdlib`
- `CVE-2022-30633 | High | 7.5 | Yes | go | Go stdlib`
- `CVE-2022-27664 | High | 7.5 | Yes | go | Go stdlib`
- `CVE-2022-30631 | High | 7.5 | Yes | go | Go stdlib`
- `CVE-2022-30635 | High | 7.5 | Yes | go | Go stdlib`
- `CVE-2022-28131 | High | 7.5 | Yes | go | Go stdlib`
- `CVE-2022-32148 | Medium | 6.5 | Yes | go | Go stdlib`
- `CVE-2022-1705 | Medium | 6.5 | Yes | go | Go stdlib`
- `CVE-2022-1962 | Medium | 5.5 | Yes | go | Go stdlib`