### PR TITLE
`securityContext` for Whereami

### DIFF
--- a/whereami/k8s-grpc/deployment.yaml
+++ b/whereami/k8s-grpc/deployment.yaml
@@ -30,8 +30,20 @@ spec:
         version: v1
     spec:
       serviceAccountName: whereami-grpc-ksa
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
       containers:
       - name: whereami-grpc
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - all
+          privileged: false
+          readOnlyRootFilesystem: true
         image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.12
         ports:
           - name: grpc

--- a/whereami/k8s/deployment.yaml
+++ b/whereami/k8s/deployment.yaml
@@ -30,8 +30,20 @@ spec:
         version: v1
     spec:
       serviceAccountName: whereami-ksa
+      securityContext:
+        fsGroup: 1000
+        runAsGroup: 1000
+        runAsNonRoot: true
+        runAsUser: 1000
       containers:
       - name: whereami
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - all
+          privileged: false
+          readOnlyRootFilesystem: true
         image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.12
         ports:
           - name: http


### PR DESCRIPTION
Implement the `securityContext` (`runAsNonRoot`, `allowPrivilegeEscalation`, `privileged`, `readOnlyRootFilesystem`) sections for the Whereami app in order to have and show security best practices by default. We recently did that for Online Boutique and Bank of Anthos and both features like Policy Controller Policies bundles and GKE Security posture really love this (no red flags anymore)! :)