### PR TITLE
Fix custom metrics autoscaling commands

### DIFF
--- a/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd.yaml
+++ b/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd.yaml
@@ -33,7 +33,7 @@ spec:
         run: custom-metric-sd
     spec:
       containers:
-      - command: ["./sd-dummy-exporter"]
+      - command: ["./direct-to-sd"]
         args:
         - --use-new-resource-model=true
         - --use-old-resource-model=false

--- a/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd.yaml
+++ b/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd.yaml
@@ -36,7 +36,7 @@ spec:
       # sample container generating custom metrics
       - name: prometheus-dummy-exporter
         image: us-docker.pkg.dev/google-samples/containers/gke/prometheus-dummy-exporter:v0.2.0
-        command: ["./prometheus-dummy-exporter"]
+        command: ["./prometheus-to-sd"]
         args:
         - --metric-name=custom_prometheus
         - --metric-value=40


### PR DESCRIPTION
This PR fixes mismatch commands stemming from an omission in https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/pull/369

More-or-less a mirror of https://github.com/GoogleCloudPlatform/k8s-stackdriver/pull/497