### PR TITLE
Revert custom metrics changes

### DIFF
--- a/custom-metrics-autoscaling/direct-to-sd/Dockerfile
+++ b/custom-metrics-autoscaling/direct-to-sd/Dockerfile
@@ -15,11 +15,11 @@
 FROM golang:1.19.2 as builder
 WORKDIR /app
 COPY * ./
-RUN CGO_ENABLED=0 GOOS=linux go build -o /direct-to-sd
+RUN CGO_ENABLED=0 GOOS=linux go build -o /sd-dummy-exporter
 
 FROM gcr.io/distroless/base-debian11
 WORKDIR /
-COPY --from=builder /direct-to-sd /direct-to-sd
+COPY --from=builder /sd-dummy-exporter /sd-dummy-exporter
 ENV PORT 8080
 USER nonroot:nonroot
-CMD ["/direct-to-sd"]
+CMD ["/sd-dummy-exporter"]

--- a/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd.yaml
+++ b/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd.yaml
@@ -33,7 +33,7 @@ spec:
         run: custom-metric-sd
     spec:
       containers:
-      - command: ["./direct-to-sd"]
+      - command: ["./sd-dummy-exporter"]
         args:
         - --use-new-resource-model=true
         - --use-old-resource-model=false

--- a/custom-metrics-autoscaling/prometheus-to-sd/Dockerfile
+++ b/custom-metrics-autoscaling/prometheus-to-sd/Dockerfile
@@ -15,11 +15,11 @@
 FROM golang:1.19.2 as builder
 WORKDIR /app
 COPY * ./
-RUN CGO_ENABLED=0 GOOS=linux go build -o /prometheus-to-sd
+RUN CGO_ENABLED=0 GOOS=linux go build -o /prometheus-dummy-exporter
 
 FROM gcr.io/distroless/base-debian11
 WORKDIR /
-COPY --from=builder /prometheus-to-sd /prometheus-to-sd
+COPY --from=builder /prometheus-dummy-exporter /prometheus-dummy-exporter
 ENV PORT 8080
 USER nonroot:nonroot
-CMD ["/prometheus-to-sd"]
+CMD ["/prometheus-dummy-exporter"]

--- a/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd.yaml
+++ b/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd.yaml
@@ -36,7 +36,7 @@ spec:
       # sample container generating custom metrics
       - name: prometheus-dummy-exporter
         image: us-docker.pkg.dev/google-samples/containers/gke/prometheus-dummy-exporter:v0.2.0
-        command: ["./prometheus-to-sd"]
+        command: ["./prometheus-dummy-exporter"]
         args:
         - --metric-name=custom_prometheus
         - --metric-value=40


### PR DESCRIPTION
This PR reverts custom metrics changes introduced in https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/pull/369 where the name of the command changed, to make sure it doesn't affect existing documents.