### PR TITLE
Update Renovate to update Dockerfiles

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
     "config:base"
   ],
   "dockerfile": {
-    "enabled": false
+    "enabled": true
   },
   "pip-compile": {
     "enabled": true,


### PR DESCRIPTION
Update Renovate to update Dockerfiles, revert back https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/pull/257, needs to be validated by @xtineskim. Could we now update Dockerfiles?

For example, we recently added the build/test in CI (https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/pull/370 + https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/pull/367), is it helping to avoid any issues you faced in the past?