### PR TITLE
Move run.sh shebang (#!/bin/bash) to top

### DIFF
--- a/guestbook/redis-follower/run.sh
+++ b/guestbook/redis-follower/run.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 
 # Copyright 2021 Google LLC
 #
@@ -14,7 +15,6 @@
 # limitations under the License.
 
 # [START gke_redis_follower_run]
-#!/bin/bash
 
 if [[ ${GET_HOSTS_FROM:-dns} == "env" ]]; then
   redis-server --replicaof ${REDIS_LEADER_SERVICE_HOST} 6379


### PR DESCRIPTION
### Background/Problem

- This fixes [#441](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/issues/441).
- If you build and run `/guestbook/redis-follower/Dockerfile`, the following error will be output:
```
/run.sh: 18: /run.sh: [[: not found
...
```

### Solution
* According the ["Google Copyright Notice Usage" doc](https://g3doc.corp.google.com/company/teams/opensource/copyright.md#build-shell-scripts-sawzall) (Google-internal doc), the shebang can be placed before the license header.
* So I have placed the shebang at the top of the file.

### Manually Tested
- I have built and run the `/guestbook/redis-follower` locally.
- I no longer see the error (`/run.sh: 18: /run.sh: [[: not found`).