### PR TITLE
Remove postgresql-postgresql-ha-pgpool from GKE Backup in the stateful sample

### DIFF
--- a/gke-stateful-postgres/helm/postgresql-bootstrap/values.yaml
+++ b/gke-stateful-postgres/helm/postgresql-bootstrap/values.yaml
@@ -93,7 +93,7 @@ gkeBackup: # Enable this for Standard GKE, ignore during Autopilot test
     components:
       - name: postgresql
         resourceKind: StatefulSet
-        resourceNames: ["postgresql-postgresql-ha-postgresql","postgresql-postgresql-ha-pgpool"]
+        resourceNames: ["postgresql-postgresql-ha-postgresql"]
         strategy:
           type: BackupAllRestoreAll
           backupAllRestoreAll: {}


### PR DESCRIPTION
removed "postgresql-postgresql-ha-pgpool" its already included and not a stateful app