### PR TITLE
Whereami cache metadata

### DIFF
--- a/whereami/README.md
+++ b/whereami/README.md
@@ -19,7 +19,7 @@ Prometheus metrics are exposed from `whereami` at `x.x.x.x/metrics` in both Flas
 `whereami` is a single-container app, designed and packaged to run on Kubernetes. In its simplest form it can be deployed in a single line with only a few parameters.
 
 ```bash
-$ kubectl run --image=us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17 --expose --port 8080 whereami
+$ kubectl run --image=us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.18 --expose --port 8080 whereami
 ```
 
 The `whereami`  pod listens on port `8080` and returns a very simple JSON response that indicates who is responding and where they live. This example assumes you're executing the `curl` command from a pod in the same K8s cluster & namespace (although the following examples show how to access from external clients):
@@ -104,7 +104,7 @@ spec:
       serviceAccountName: whereami
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.18
         ports:
           - name: http
             containerPort: 8080 #The application is listening on port 8080
@@ -548,7 +548,7 @@ If you'd like to deploy `whereami` via its Helm chart, you could leverage the fo
 Deploy the default setup of `whereami` (HTTP frontend):
 ```sh
 helm install whereami oci://us-docker.pkg.dev/google-samples/charts/whereami \
-    --version 1.2.17
+    --version 1.2.18
 ```
 
 Deploy `whereami` as HTTP backend by running the previous `helm install` command with the following parameters:

--- a/whereami/cloudbuild.yaml
+++ b/whereami/cloudbuild.yaml
@@ -21,9 +21,9 @@ steps:
   args:
     - 'build'
     - '-t'
-    - 'gcr.io/google-samples/whereami:v1.2.17'
+    - 'gcr.io/google-samples/whereami:v1.2.18'
     - '-t'
-    - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17'
+    - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.18'
     - '.'
   dir: 'whereami'
 - name: ubuntu
@@ -33,8 +33,8 @@ steps:
     curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
     cd whereami/helm-chart
     helm package .
-    helm push whereami-1.2.17.tgz oci://us-docker.pkg.dev/google-samples/charts
+    helm push whereami-1.2.18.tgz oci://us-docker.pkg.dev/google-samples/charts
 
 images:
-  - 'gcr.io/google-samples/whereami:v1.2.17'
-  - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17'
+  - 'gcr.io/google-samples/whereami:v1.2.18'
+  - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.18'

--- a/whereami/helm-chart/Chart.yaml
+++ b/whereami/helm-chart/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.17
+version: 1.2.18
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.2.17"
+appVersion: "v1.2.18"

--- a/whereami/k8s-grpc/deployment.yaml
+++ b/whereami/k8s-grpc/deployment.yaml
@@ -46,7 +46,7 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.18
         ports:
           - name: grpc
             containerPort: 9090

--- a/whereami/k8s/deployment.yaml
+++ b/whereami/k8s/deployment.yaml
@@ -46,7 +46,7 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.17
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.18
         ports:
           - name: http
             containerPort: 8080

--- a/whereami/whereami_payload.py
+++ b/whereami/whereami_payload.py
@@ -44,13 +44,14 @@ class WhereamiPayload(object):
         self.payload = {}
         self.gce_metadata = {} # this will cache the results from calling GCE metadata
 
-        # grab info from GCE metadata
-        r = requests.get(METADATA_URL + '?recursive=true',
-                             headers=METADATA_HEADERS)
-        if r.ok:
-            logging.info("Successfully accessed GCE metadata endpoint.")
-            self.gce_metadata = r.json()
-        else:
+        try:
+            # grab info from GCE metadata
+            r = requests.get(METADATA_URL + '?recursive=true',
+                                headers=METADATA_HEADERS)
+            if r.ok:
+                logging.info("Successfully accessed GCE metadata endpoint.")
+                self.gce_metadata = r.json()
+        except:
             logging.warning("Unable to access GCE metadata endpoint.")
 
 

--- a/whereami/whereami_payload.py
+++ b/whereami/whereami_payload.py
@@ -42,6 +42,17 @@ class WhereamiPayload(object):
     def __init__(self):
 
         self.payload = {}
+        self.gce_metadata = {} # this will cache the results from calling GCE metadata
+
+        # grab info from GCE metadata
+        r = requests.get(METADATA_URL + '?recursive=true',
+                             headers=METADATA_HEADERS)
+        if r.ok:
+            logging.info("Successfully accessed GCE metadata endpoint.")
+            self.gce_metadata = r.json()
+        else:
+            logging.warning("Unable to access GCE metadata endpoint.")
+
 
     def build_payload(self, request_headers):
 
@@ -107,30 +118,30 @@ class WhereamiPayload(object):
 
             return backend_result
 
-        # grab info from GCE metadata
-        try:
-            r = requests.get(METADATA_URL + '?recursive=true',
-                             headers=METADATA_HEADERS)
+        # grab info from cached GCE metadata
+        if len(self.gce_metadata):
+            logging.info("Found cached GCE metadata.")
+
             # get project / zone info
-            self.payload['project_id'] = r.json()['project']['projectId']
-            self.payload['zone'] = r.json()['instance']['zone'].split('/')[-1]
+            self.payload['project_id'] = self.gce_metadata['project']['projectId']
+            self.payload['zone'] = self.gce_metadata['instance']['zone'].split('/')[-1]
 
             # if we're running in GKE, we can also get cluster name
             try:
-                self.payload['cluster_name'] = r.json()['instance']['attributes']['cluster-name']
+                self.payload['cluster_name'] = self.gce_metadata['instance']['attributes']['cluster-name']
             except:
                 logging.warning("Unable to capture GKE cluster name.")
             # if we're running on Google, grab the instance ID and default Google service account
             try:
-                self.payload['gce_instance_id'] = str(r.json()['instance']['id']) # casting to str as value can be alphanumeric on Cloud Run
+                self.payload['gce_instance_id'] = str(self.gce_metadata['instance']['id']) # casting to str as value can be alphanumeric on Cloud Run
             except:
                 logging.warning("Unable to capture GCE instance ID.")
             try:
-                self.payload['gce_service_account'] = r.json()['instance']['serviceAccounts']['default']['email']
+                self.payload['gce_service_account'] = self.gce_metadata['instance']['serviceAccounts']['default']['email']
             except:
                 logging.warning("Unable to capture GCE service account.")
-        except:
-            logging.warning("Unable to access GCE metadata endpoint.")
+        else:
+            logging.warning("GCE metadata unavailable.")
 
         # get node name via downward API
         if os.getenv('NODE_NAME'):
@@ -172,7 +183,7 @@ class WhereamiPayload(object):
         if os.getenv('METADATA'):
             self.payload['metadata'] = os.getenv('METADATA')
         else:
-            logging.warning("Unable to capture metadata.")
+            logging.warning("Unable to capture metadata environment variable.")
 
         # should we call a backend service?
         if os.getenv('BACKEND_ENABLED') == 'True':


### PR DESCRIPTION
Made a modification to `whereami` to cache the GCE instance metadata when the `whereami_payload` object is created. Previous to this update, each call to `whereami` would also hit the local metadata endpoint, which added a lot of latency for no tangible benefit (the metadata we're scraping doesn't change for the lifetime of the container). local testing bumped RPS by a factor or 4-8x at same resource consumption. 

Tested locally, on Cloud Worktation, on Cloud Run, and on GKE in both HTTP & gRPC modes. 

```
$ grpcurl whereami-grpc-01-b4i6txyukq-uc.a.run.app:443 whereami.Whereami/GetPayload
{
  "pod_name": "localhost",
  "pod_name_emoji": "😴",
  "project_id": "spanner-reporter-01",
  "timestamp": "2023-01-17T19:22:51",
  "zone": "us-central1-1",
  "gce_instance_id": "0071bb48157a2593e287744d134d312f2e099c4dc08daaaed011d052037f2b686f7990cb8d618a55d2873654797323de7def3ca3e4252231eec5ccff3836fee439",
  "gce_service_account": "28061665984-compute@developer.gserviceaccount.com"
}
```

```
$ curl 35.232.22.227
{
  "backend_result": {
    "cluster_name": "ap-asm-1",
    "gce_instance_id": "8238644740387196205",
    "gce_service_account": "am-arg-01.svc.id.goog",
    "host_header": "whereami-backend",
    "metadata": "backend",
    "node_name": "gk3-ap-asm-1-nap-kngdrcpt-08300ff7-zvd6",
    "pod_ip": "10.126.128.93",
    "pod_name": "whereami-backend-6d76d56fbf-kd56g",
    "pod_name_emoji": "🚶🏻",
    "pod_namespace": "default",
    "pod_service_account": "whereami-backend",
    "project_id": "am-arg-01",
    "timestamp": "2023-01-17T19:27:43",
    "zone": "us-central1-b"
  },
  "cluster_name": "ap-asm-1",
  "gce_instance_id": "5514516116051545384",
  "gce_service_account": "am-arg-01.svc.id.goog",
  "host_header": "35.232.22.227",
  "metadata": "frontend",
  "node_name": "gk3-ap-asm-1-nap-kngdrcpt-1404e0a0-vmxm",
  "pod_ip": "10.126.128.136",
  "pod_name": "whereami-frontend-7484d594b9-dq7kr",
  "pod_name_emoji": "🫵",
  "pod_namespace": "default",
  "pod_service_account": "whereami-frontend",
  "project_id": "am-arg-01",
  "timestamp": "2023-01-17T19:27:43",
  "zone": "us-central1-a"
}
```