### PR TITLE
Whereami metadata cache retry

### DIFF
--- a/whereami/README.md
+++ b/whereami/README.md
@@ -19,7 +19,7 @@ Prometheus metrics are exposed from `whereami` at `x.x.x.x/metrics` in both Flas
 `whereami` is a single-container app, designed and packaged to run on Kubernetes. In its simplest form it can be deployed in a single line with only a few parameters.
 
 ```bash
-$ kubectl run --image=us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.18 --expose --port 8080 whereami
+$ kubectl run --image=us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19 --expose --port 8080 whereami
 ```
 
 The `whereami`  pod listens on port `8080` and returns a very simple JSON response that indicates who is responding and where they live. This example assumes you're executing the `curl` command from a pod in the same K8s cluster & namespace (although the following examples show how to access from external clients):
@@ -104,7 +104,7 @@ spec:
       serviceAccountName: whereami
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.18
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - name: http
             containerPort: 8080 #The application is listening on port 8080
@@ -548,7 +548,7 @@ If you'd like to deploy `whereami` via its Helm chart, you could leverage the fo
 Deploy the default setup of `whereami` (HTTP frontend):
 ```sh
 helm install whereami oci://us-docker.pkg.dev/google-samples/charts/whereami \
-    --version 1.2.18
+    --version 1.2.19
 ```
 
 Deploy `whereami` as HTTP backend by running the previous `helm install` command with the following parameters:

--- a/whereami/cloudbuild.yaml
+++ b/whereami/cloudbuild.yaml
@@ -21,9 +21,9 @@ steps:
   args:
     - 'build'
     - '-t'
-    - 'gcr.io/google-samples/whereami:v1.2.18'
+    - 'gcr.io/google-samples/whereami:v1.2.19'
     - '-t'
-    - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.18'
+    - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19'
     - '.'
   dir: 'whereami'
 - name: ubuntu
@@ -33,8 +33,8 @@ steps:
     curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
     cd whereami/helm-chart
     helm package .
-    helm push whereami-1.2.18.tgz oci://us-docker.pkg.dev/google-samples/charts
+    helm push whereami-1.2.19.tgz oci://us-docker.pkg.dev/google-samples/charts
 
 images:
-  - 'gcr.io/google-samples/whereami:v1.2.18'
-  - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.18'
+  - 'gcr.io/google-samples/whereami:v1.2.19'
+  - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19'

--- a/whereami/helm-chart/Chart.yaml
+++ b/whereami/helm-chart/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.18
+version: 1.2.19
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.2.18"
+appVersion: "v1.2.19"

--- a/whereami/k8s-grpc/deployment.yaml
+++ b/whereami/k8s-grpc/deployment.yaml
@@ -46,7 +46,7 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.18
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - name: grpc
             containerPort: 9090

--- a/whereami/k8s/deployment.yaml
+++ b/whereami/k8s/deployment.yaml
@@ -46,7 +46,7 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.18
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
         ports:
           - name: http
             containerPort: 8080

--- a/whereami/whereami_payload.py
+++ b/whereami/whereami_payload.py
@@ -48,6 +48,8 @@ class WhereamiPayload(object):
         self.gce_metadata = {} # this will cache the results from calling GCE metadata
 
         # configure retries for GCE metadata GET
+        # we're doing this because, on GKE, metadata endpoint can take a few seconds to be available
+        # see https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#limitations
         session = requests.Session()
         adapter = HTTPAdapter(max_retries=Retry(total=3, backoff_factor=1, allowed_methods=['GET'])) #, status_forcelist=[429, 500, 502, 503, 504]))
         session.mount("http://", adapter)

--- a/whereami/whereami_payload.py
+++ b/whereami/whereami_payload.py
@@ -49,7 +49,7 @@ class WhereamiPayload(object):
 
         # configure retries for GCE metadata GET
         session = requests.Session()
-        adapter = HTTPAdapter(max_retries=Retry(total=4, backoff_factor=1, allowed_methods=['GET'])) #, status_forcelist=[429, 500, 502, 503, 504]))
+        adapter = HTTPAdapter(max_retries=Retry(total=3, backoff_factor=1, allowed_methods=['GET'])) #, status_forcelist=[429, 500, 502, 503, 504]))
         session.mount("http://", adapter)
         session.mount("https://", adapter)
 

--- a/whereami/whereami_payload.py
+++ b/whereami/whereami_payload.py
@@ -6,6 +6,9 @@ import emoji
 import logging
 from logging.config import dictConfig
 import requests
+from requests.adapters import HTTPAdapter
+import urllib3
+from urllib3 import Retry
 # gRPC stuff
 import grpc
 from six import b
@@ -44,9 +47,15 @@ class WhereamiPayload(object):
         self.payload = {}
         self.gce_metadata = {} # this will cache the results from calling GCE metadata
 
+        # configure retries for GCE metadata GET
+        session = requests.Session()
+        adapter = HTTPAdapter(max_retries=Retry(total=4, backoff_factor=1, allowed_methods=['GET'])) #, status_forcelist=[429, 500, 502, 503, 504]))
+        session.mount("http://", adapter)
+        session.mount("https://", adapter)
+
         try:
             # grab info from GCE metadata
-            r = requests.get(METADATA_URL + '?recursive=true',
+            r = session.get(METADATA_URL + '?recursive=true',
                                 headers=METADATA_HEADERS)
             if r.ok:
                 logging.info("Successfully accessed GCE metadata endpoint.")


### PR DESCRIPTION
Had to implement retry logic for GCE metadata `GET` due to [this](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#limitations):

```
The GKE metadata server takes a few seconds to start accepting requests on a newly created Pod. Therefore, attempts to authenticate using Workload Identity within the first few seconds of a Pod's life might fail. Retrying the call will resolve the problem. See Troubleshooting for more details.
```

So implemented this:
```
adapter = HTTPAdapter(max_retries=Retry(total=3, backoff_factor=1, allowed_methods=['GET']))
```