### PR TITLE
Updated cloud sql proxy image version to latest

### DIFF
--- a/wordpress-persistent-disks/wordpress_cloudsql.yaml.template
+++ b/wordpress-persistent-disks/wordpress_cloudsql.yaml.template
@@ -42,7 +42,7 @@ spec:
         # of your Cloud SQL instance. The format is
         # $PROJECT:$REGION:$INSTANCE
         - name: cloudsql-proxy
-          image: gcr.io/cloudsql-docker/gce-proxy:latest
+          image: gcr.io/cloudsql-docker/gce-proxy:1.33.2
           command: ["/cloud_sql_proxy",
                     "-instances=${INSTANCE_CONNECTION_NAME}=tcp:3306",
                     # If running on a VPC, the Cloud SQL proxy can connect via Private IP. See:

--- a/wordpress-persistent-disks/wordpress_cloudsql.yaml.template
+++ b/wordpress-persistent-disks/wordpress_cloudsql.yaml.template
@@ -42,7 +42,7 @@ spec:
         # of your Cloud SQL instance. The format is
         # $PROJECT:$REGION:$INSTANCE
         - name: cloudsql-proxy
-          image: gcr.io/cloudsql-docker/gce-proxy:1.11
+          image: gcr.io/cloudsql-docker/gce-proxy:latest
           command: ["/cloud_sql_proxy",
                     "-instances=${INSTANCE_CONNECTION_NAME}=tcp:3306",
                     # If running on a VPC, the Cloud SQL proxy can connect via Private IP. See:


### PR DESCRIPTION
Fixed issue "Error Establishing a Database Connection" when setting up Wordpress tutorial.

Question: The latest version in https://pantheon.corp.google.com/gcr/images/cloudsql-docker/GLOBAL/gce-proxy is 1.33.2

Should I use latest or 1.33.2 instead?