### PR TITLE
Adapt names to reviewed Kueue documentation

### DIFF
--- a/batch/kueue-intro/cluster-queue.yaml
+++ b/batch/kueue-intro/cluster-queue.yaml
@@ -16,29 +16,29 @@
 apiVersion: kueue.x-k8s.io/v1alpha2
 kind: ClusterQueue
 metadata:
-  name: cq
+  name: cluster-queue
 spec:
   namespaceSelector: {}
   queueingStrategy: BestEffortFIFO # Default queueing strategy
   resources:
   - name: "cpu"
     flavors:
-    - name: default
+    - name: default-flavor
       quota:
         min: 10
   - name: "memory"
     flavors:
-    - name: default
+    - name: default-flavor
       quota:
         min: 10Gi
   - name: "nvidia.com/gpu"
     flavors:
-    - name: default
+    - name: default-flavor
       quota:
         min: 10
   - name: "ephemeral-storage"
     flavors:
-    - name: default
+    - name: default-flavor
       quota:
         min: 10Gi
 # [END gke_batch_kueue_intro_cq]

--- a/batch/kueue-intro/flavors.yaml
+++ b/batch/kueue-intro/flavors.yaml
@@ -16,5 +16,5 @@
 apiVersion: kueue.x-k8s.io/v1alpha2
 kind: ResourceFlavor
 metadata:
-  name: default # This ResourceFlavor will be used for all the resources
+  name: default-flavor # This ResourceFlavor will be used for all the resources
 # [END gke_batch_kueue_intro_flavors]

--- a/batch/kueue-intro/local-queue.yaml
+++ b/batch/kueue-intro/local-queue.yaml
@@ -19,7 +19,7 @@ metadata:
   namespace: team-a # LocalQueue under team-a namespace
   name: team-a-lq
 spec:
-  clusterQueue: cq # Point to the ClusterQueue cq
+  clusterQueue: cluster-queue # Point to the ClusterQueue
 ---
 apiVersion: kueue.x-k8s.io/v1alpha2
 kind: LocalQueue
@@ -27,5 +27,5 @@ metadata:
   namespace: team-b # LocalQueue under team-b namespace
   name: team-b-lq
 spec:
-  clusterQueue: cq # Point to the ClusterQueue cq
+  clusterQueue: cluster-queue # Point to the ClusterQueue
 # [END gke_batch_kueue_intro_lq]

--- a/batch/kueue-intro/team-a-job.yaml
+++ b/batch/kueue-intro/team-a-job.yaml
@@ -17,7 +17,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   namespace: team-a # Job under team-a namespace
-  generateName: sample-job-
+  generateName: sample-team-a-job-
   annotations:
     kueue.x-k8s.io/queue-name: team-a-lq # Point to the LocalQueue
 spec:

--- a/batch/kueue-intro/team-b-job.yaml
+++ b/batch/kueue-intro/team-b-job.yaml
@@ -17,7 +17,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   namespace: team-b # Job under team-b namespace
-  generateName: sample-job-
+  generateName: sample-team-b-job-
   annotations:
     kueue.x-k8s.io/queue-name: team-b-lq # Point to the LocalQueue
 spec:


### PR DESCRIPTION
The Kueue documentation has been updated recently.

This PR uses the same ResourceFlavor names than in documentation.

It also gives different names to jobs generated for both teams, so the output of the commands in the tutorial are more descriptive.