### PR TITLE
replace  only=production with omit=dev

### DIFF
--- a/quickstart/nodejs/Dockerfile
+++ b/quickstart/nodejs/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /usr/src/app
 COPY package*.json ./
 
 # Install production dependencies.
-RUN npm install --only=production
+RUN npm install --omit=dev
 
 # Copy local code to the container image.
 COPY . ./


### PR DESCRIPTION
When I run a build for the [Quickstart](https://cloud.google.com/kubernetes-engine/docs/quickstarts/deploy-app-container-image#containerizing_an_app) I get the warning:

```
Step 4/7 : RUN npm install --production
 Running in 0f1f5243b9bc
npm WARN config production Use `--omit=dev` instead.
```

This updates from `--only=production` to `--omit=dev`

I have tested the Quickstart. I no longer see the warning and it still works as expected.