### PR TITLE
cleanup: add renovate rule to skip springboot upgrade

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -33,5 +33,11 @@
   },
   "nuget":{
     "addLabels": ["lang: dotnet"]
-  }
+  },
+  "packageRules": [
+    {
+      "matchPackageNames": ["org.springframework.boot:spring-boot-starter-parent"],
+      "allowedVersions": "<3.0.0"
+    }
+  ]
 }


### PR DESCRIPTION
#### Description
- This change is related to https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/pull/410
- Renovate tries to update springboot-starter version which relies on Java17 
- Our CI doesn't support Java 17 yet, thus we have to wait until that change is done.
- Until then we can skip it. 