### PR TITLE
Changes to adapt to tutorial literature

### DIFF
--- a/batch/kueue-cohort/cq-team-a.yaml
+++ b/batch/kueue-cohort/cq-team-a.yaml
@@ -29,7 +29,7 @@ spec:
       resources:
       - name: "cpu"
         nominalQuota: 10
-        borrowingLimit: 15
+        borrowingLimit: 5
       - name: "memory"
         nominalQuota: 10Gi
         borrowingLimit: 15Gi


### PR DESCRIPTION
Changed borrowingLimit to 5 in the ClusterQueues to bring the samples to the same figures as used in the tutorial literature