### PR TITLE
Whereami 3.11 01

### DIFF
--- a/whereami/Dockerfile
+++ b/whereami/Dockerfile
@@ -6,8 +6,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   wget && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* && \
-  wget -O /bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.18/grpc_health_probe-linux-amd64 && \ 
-  chmod +x /bin/grpc_health_probe && \
   wget -O /bin/curl https://github.com/moparisthebest/static-curl/releases/download/v8.0.1/curl-amd64 && \ 
   chmod +x /bin/curl
 COPY ./requirements.txt /app/requirements.txt

--- a/whereami/Dockerfile
+++ b/whereami/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.9-slim
+FROM python:3.11.3-slim
 
 #MAINTAINER Alex Mattson "alex.mattson@gmail.com"
 
@@ -6,9 +6,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   wget && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* && \
-  wget -O /bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.14/grpc_health_probe-linux-amd64 && \ 
+  wget -O /bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.18/grpc_health_probe-linux-amd64 && \ 
   chmod +x /bin/grpc_health_probe && \
-  wget -O /bin/curl https://github.com/moparisthebest/static-curl/releases/download/v7.86.0/curl-amd64 && \ 
+  wget -O /bin/curl https://github.com/moparisthebest/static-curl/releases/download/v8.0.1/curl-amd64 && \ 
   chmod +x /bin/curl
 COPY ./requirements.txt /app/requirements.txt
 

--- a/whereami/README.md
+++ b/whereami/README.md
@@ -529,9 +529,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   wget && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* && \
-  wget -O /bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/v0.4.14/grpc_health_probe-linux-amd64 && \
-  chmod +x /bin/grpc_health_probe && \
-  wget -O /bin/curl https://github.com/moparisthebest/static-curl/releases/download/v7.86.0/curl-amd64 && \
+  wget -O /bin/curl https://github.com/moparisthebest/static-curl/releases/download/v8.0.1/curl-amd64 && \
   chmod +x /bin/curl
 USER cnb
 EOF

--- a/whereami/README.md
+++ b/whereami/README.md
@@ -19,7 +19,7 @@ Prometheus metrics are exposed from `whereami` at `x.x.x.x/metrics` in both Flas
 `whereami` is a single-container app, designed and packaged to run on Kubernetes. In its simplest form it can be deployed in a single line with only a few parameters.
 
 ```bash
-$ kubectl run --image=us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19 --expose --port 8080 whereami
+$ kubectl run --image=us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.20 --expose --port 8080 whereami
 ```
 
 The `whereami`  pod listens on port `8080` and returns a very simple JSON response that indicates who is responding and where they live. This example assumes you're executing the `curl` command from a pod in the same K8s cluster & namespace (although the following examples show how to access from external clients):
@@ -104,7 +104,7 @@ spec:
       serviceAccountName: whereami
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.20
         ports:
           - name: http
             containerPort: 8080 #The application is listening on port 8080
@@ -552,7 +552,7 @@ If you'd like to deploy `whereami` via its Helm chart, you could leverage the fo
 Deploy the default setup of `whereami` (HTTP frontend):
 ```sh
 helm install whereami oci://us-docker.pkg.dev/google-samples/charts/whereami \
-    --version 1.2.19
+    --version 1.2.20
 ```
 
 Deploy `whereami` as HTTP backend by running the previous `helm install` command with the following parameters:

--- a/whereami/cloudbuild.yaml
+++ b/whereami/cloudbuild.yaml
@@ -21,9 +21,9 @@ steps:
   args:
     - 'build'
     - '-t'
-    - 'gcr.io/google-samples/whereami:v1.2.19'
+    - 'gcr.io/google-samples/whereami:v1.2.20'
     - '-t'
-    - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19'
+    - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.20'
     - '.'
   dir: 'whereami'
 - name: ubuntu
@@ -33,8 +33,8 @@ steps:
     curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
     cd whereami/helm-chart
     helm package .
-    helm push whereami-1.2.19.tgz oci://us-docker.pkg.dev/google-samples/charts
+    helm push whereami-1.2.20.tgz oci://us-docker.pkg.dev/google-samples/charts
 
 images:
-  - 'gcr.io/google-samples/whereami:v1.2.19'
-  - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19'
+  - 'gcr.io/google-samples/whereami:v1.2.20'
+  - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.20'

--- a/whereami/helm-chart/Chart.yaml
+++ b/whereami/helm-chart/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.19
+version: 1.2.20
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.2.19"
+appVersion: "v1.2.20"

--- a/whereami/k8s-grpc/deployment.yaml
+++ b/whereami/k8s-grpc/deployment.yaml
@@ -46,7 +46,7 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.20
         ports:
           - name: grpc
             containerPort: 9090

--- a/whereami/k8s-grpc/deployment.yaml
+++ b/whereami/k8s-grpc/deployment.yaml
@@ -53,12 +53,12 @@ spec:
           - name: http
             containerPort: 8000 # prom metrics
         readinessProbe:
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:9090"]
+          grpc:
+            port: 9090
           initialDelaySeconds: 5
         livenessProbe:
-          exec:
-            command: ["/bin/grpc_health_probe", "-addr=:9090"]
+          grpc:
+            port: 9090
           initialDelaySeconds: 10
         env:
           - name: NODE_NAME

--- a/whereami/k8s/deployment.yaml
+++ b/whereami/k8s/deployment.yaml
@@ -46,7 +46,7 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.19
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.20
         ports:
           - name: http
             containerPort: 8080


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/issues/623

Bumped base image of `whereami` to Python 3.11.3 slim and removed legacy gRPC exec-based probes + accompanying binary (which included some CVEs, replacing with K8s-native gRPC health checking.

Tested both HTTP and gRPC modes of `whereami` successfully. 