### PR TITLE
Fix typo in the PubSub sample

### DIFF
--- a/cloud-pubsub/main.py
+++ b/cloud-pubsub/main.py
@@ -33,13 +33,13 @@ def main():
         print(f"[{datetime.datetime.now()}] Processed: {message.message_id}")
         message.ack()
 
-    streaming_pull_feature = subscriber.subscribe(
+    streaming_pull_future = subscriber.subscribe(
         subscription_path, callback=callback)
     print(f"Pulling messages from {subscription_path}...")
 
     with subscriber:
         try:
-            streaming_pull_feature.result()
+            streaming_pull_future.result()
         except Exception as e:
             print(e)
 # [END container_pubsub_pull]


### PR DESCRIPTION
This PR fixes a typo in the PubSub samples, where `feature` should be `future`, to match https://cloud.google.com/python/docs/reference/pubsub/latest/google.cloud.pubsub_v1.subscriber.futures.StreamingPullFuture