### PR TITLE
Ignore Renovate deps for security/language-vulns

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -33,5 +33,6 @@
   },
   "nuget":{
     "addLabels": ["lang: dotnet"]
-  }
+  },
+  "ignorePaths": ["security/language-vulns/**"]
 }

--- a/security/language-vulns/maven/pom.xml
+++ b/security/language-vulns/maven/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.14</version>
+		<version>2.1.3.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>


### PR DESCRIPTION
This PR:
- Reverts an unintentional dependency bump on `security/language-vulns`
- Modifies the Renovate config to ignore that directory moving forward

This is due to the fact that these samples _intentionally_ hosts outdated images for demo purposes.