### PR TITLE
Fix dns.tf typo

### DIFF
--- a/autopilot/networking-tutorial/dns.tf
+++ b/autopilot/networking-tutorial/dns.tf
@@ -18,7 +18,7 @@ terraform {
   required_version = "~> 1.3"
 }
  
-variable "base_domin" {
+variable "base_domain" {
   type        = string
   description = "Your base domain"
 }
@@ -37,7 +37,7 @@ resource "google_compute_global_address" "default" {
  
 resource "google_dns_managed_zone" "default" {
   name        = var.name
-  dns_name    = "${var.name}.${var.base_domin}."
+  dns_name    = "${var.name}.${var.base_domain}."
   description = "DNS Zone for web application"
 }
  


### PR DESCRIPTION
The `base_domin` Terraform variable has a typo and was renamed to `base_domain`.