### PR TITLE
Fix t5 container build

### DIFF
--- a/ai-ml/t5-model-serving/client-app/Dockerfile
+++ b/ai-ml/t5-model-serving/client-app/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.10-alpine
+FROM python:3.11.5-alpine
 
 ARG PORT=8050
 ENV PORT=${PORT}
@@ -23,6 +23,22 @@ WORKDIR /app
 
 COPY requirements.txt /app
 COPY src/ /app
+
+# https://github.com/pandas-dev/pandas/issues/50945#issuecomment-1407044982
+RUN apk update
+RUN apk add \
+    build-base \
+    freetds-dev \
+    g++ \
+    gcc \
+    tar \
+    gfortran \
+    gnupg \
+    libffi-dev \
+    libpng-dev \
+    libsasl \
+    openblas-dev \
+    openssl-dev
 
 RUN pip3 install --no-cache-dir -r requirements.txt
 

--- a/ai-ml/t5-model-serving/client-app/requirements.txt
+++ b/ai-ml/t5-model-serving/client-app/requirements.txt
@@ -1,3 +1,3 @@
-fast-dash
-requests
-gunicorn
+fast-dash==0.2.6
+requests==2.31.0
+gunicorn==21.2.0


### PR DESCRIPTION
This fixes the T5 sample container build, which was failing on the main branch.

Note that the container build takes ~8 minutes to complete from scratch.