### PR TITLE
Update helloweb-hpa.yaml

### DIFF
--- a/hello-app/manifests/helloweb-hpa.yaml
+++ b/hello-app/manifests/helloweb-hpa.yaml
@@ -15,7 +15,7 @@
 
 # [START gke_manifests_helloweb_hpa_horizontalpodautoscaler_cpu]
 # [START container_helloapp_horizontal_pod_autoscaler]
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: cpu


### PR DESCRIPTION
A Google stakeholder instructed that the API version is deprecated and we should update it

Deprecation notice: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v126

Related tutorial: https://cloud.google.com/kubernetes-engine/docs/tutorials/autoscaling-metrics#step4