### PR TITLE
Add demos/ folder for point-in-time content

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -34,5 +34,8 @@
   "nuget":{
     "addLabels": ["lang: dotnet"]
   },
-  "ignorePaths": ["security/language-vulns/**"]
+  "ignorePaths": [
+    "demos/**",
+    "security/language-vulns/**"
+  ]
 }

--- a/demos/README.md
+++ b/demos/README.md
@@ -1,6 +1,6 @@
 # Demos
 
 This directory contains demo content and supporting reference material from point-in-time content
-like blog posts. It is not kept date, or dependency managed like other folders in this repository.
+like blog posts. Samples within this directory may not necessarily be kept up-to-date.
 
-It is explicitly excluded from the [Mend Renovate configuration](../.github/renovate.json) 
+Note that this directory is explicitly excluded from the [Renovate configuration](../.github/renovate.json).

--- a/demos/README.md
+++ b/demos/README.md
@@ -1,0 +1,6 @@
+# Demos
+
+This directory contains demo content and supporting reference material from point-in-time content
+like blog posts. It is not kept date, or dependency managed like other folders in this repository.
+
+It is explicitly excluded from the [Mend Renovate configuration](../.github/renovate.json) 


### PR DESCRIPTION
The demos/ folder can be used for demo content or blog post material that is associated with a specific point-in-time reference material (like a blog post). This directory is ignored by Mend Renovate, to reduce additional review toil for content added to this directory.