### PR TITLE
fix: Fix client-app and model in t5-model tutorial

### DIFF
--- a/ai-ml/t5-model-serving/client-app/README.md
+++ b/ai-ml/t5-model-serving/client-app/README.md
@@ -5,14 +5,14 @@ Simple Client Application base on [fastdash](https://fastdash.app/) Python modul
 ## Package App
 
 ```bash
-export IMAGE="gcr.io/$GOOGLE_CLOUD_PROJECT/apps/fastdash:latest"
+export IMAGE="us-central1-docker.pkg.dev/${PROJECT_ID}/models/fastdash:latest"
 docker buildx build --tag "$IMAGE" .
 ```
 
 ## Storing the Client App
 
 ```bash
-gcloud auth configure-docker gcr.io --quiet
+gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
 docker push "$IMAGE"
 ```
 

--- a/ai-ml/t5-model-serving/client-app/src/app.py
+++ b/ai-ml/t5-model-serving/client-app/src/app.py
@@ -29,7 +29,7 @@ LANG_MAP = {
   "en": "English",
   "fr": "French",
   "de": "German",
-  "es": "Spanish",
+  "ro": "Romanian",
 }
 
 logger.info(f"Model prediction: {PREDICTION_URL}")
@@ -40,15 +40,18 @@ def text_to_text_function(text: str = "Hello World", from_lang=LANG_MAP, to_lang
   resp = requests.post(PREDICTION_URL, json=payload, headers=headers)
   if resp.status_code == 200:
     content = resp.json()
-    return content.get("text")
+    resp = content.get("text")
   else:
-    return "Oops, something went wrong!"
+    resp = "Oops, something went wrong!"
+
+  return resp
 
 dash = FastDash(
   callback_fn=text_to_text_function,
   title="T5 model serving",
   github_url=GITHUB_URL,
+  run_kwargs=dict(debug=__name__ == "__main__", port=8050),
 )
 
 if __name__ == "__main__":
-  dash.run_server(debug=True, port=8050)
+  dash.run()

--- a/ai-ml/t5-model-serving/model/.gcloudignore
+++ b/ai-ml/t5-model-serving/model/.gcloudignore
@@ -1,1 +1,2 @@
 README.md
+.venv

--- a/ai-ml/t5-model-serving/model/README.md
+++ b/ai-ml/t5-model-serving/model/README.md
@@ -12,7 +12,7 @@ Build stages:
 
 You can configure the build process by setting docker build arguments:
 
-* `BASE_IMAGE` - base image to use for the final container (default: `pytorch/torchserve:latest-cpu`)
+* `BASE_IMAGE` - base image to use for the final container (default: `pytorch/torchserve:0.7.1-cpu`)
 * `MODEL_NAME` - name of the model to download from huggingface (default: `t5-small`)
 * `MODEL_REPO` - repository of the model to download with git (default: `https://huggingface.co/${MODEL_NAME}`)
 * `MODEL_VERSION` - version of the model to download from huggingface (default: `1.0`)
@@ -36,13 +36,13 @@ Build docker image:
 ```bash
 export MODEL_NAME="t5-small"
 export MODEL_VERSION="1.0"
-export MODEL_IMAGE="gcr.io/$GOOGLE_CLOUD_PROJECT/models/$MODEL_NAME:$MODEL_VERSION-$MACHINE"
+export MODEL_IMAGE="us-central1-docker.pkg.dev/$GOOGLE_CLOUD_PROJECT/models/$MODEL_NAME:$MODEL_VERSION-$MACHINE"
 docker buildx build \
   --tag "$MODEL_IMAGE" \
-  --build-arg BASE_IMAGE="pytorch/torchserve:latest-$MACHINE" \
+  --build-arg BASE_IMAGE="pytorch/torchserve:0.7.1-$MACHINE" \
   --build-arg MODEL_NAME \
   --build-arg MODEL_VERSION .
-gcloud auth configure-docker gcr.io --quiet
+gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
 docker push "$MODEL_IMAGE"
 ```
 
@@ -51,7 +51,7 @@ docker push "$MODEL_IMAGE"
 Available substitutions:
 
 * `_MACHINE` - type of base image - `cpu` or `gpu` (default: `cpu`)
-* `_BASE_IMAGE` - base image to use for the final container (default: `pytorch/torchserve:latest-${_MACHINE}`)
+* `_BASE_IMAGE` - base image to use for the final container (default: `pytorch/torchserve:0.7.1-${_MACHINE}`)
 * `_MODEL_NAME` - name of the model to download from huggingface (default: `t5-small`)
 * `_MODEL_REPO` - repository of the model to download with git (default: `https://huggingface.co/${_MODEL_NAME}`)
 * `_MODEL_VERSION` - version of the model to download from huggingface (default: `1.0`)

--- a/ai-ml/t5-model-serving/model/handler.py
+++ b/ai-ml/t5-model-serving/model/handler.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 class TransformersSeqGeneration(BaseHandler, ABC):
     _LANG_MAP = {
-        "es": "Spanish",
+        "ro": "Romanian",
         "fr": "French",
         "de": "German",
         "en": "English",

--- a/ai-ml/t5-model-serving/model/requirements.txt
+++ b/ai-ml/t5-model-serving/model/requirements.txt
@@ -1,2 +1,2 @@
-t5
-transformers
+t5==0.9.4
+transformers==4.34.0


### PR DESCRIPTION
After #887 version of the API of the fast-dash library has changed and the current version of the application does not work. 

- Update client-app to use actual API of fast-dash lib
- Freeze dependencies for model
- Update model's and client-app's README files