### PR TITLE
Add six module

### DIFF
--- a/whereami/requirements.txt
+++ b/whereami/requirements.txt
@@ -14,3 +14,4 @@ opentelemetry-propagator-gcp
 opentelemetry-exporter-gcp-trace
 opentelemetry-instrumentation-flask
 opentelemetry-instrumentation-requests
+six


### PR DESCRIPTION
This PR fixes `ModuleNotFoundError` on the `whereami` sample application.

closes #983 