### PR TITLE
Update Kafka version in my-cluster.yaml

### DIFF
--- a/streaming/kafka-strimzi/manifests/01-basic-cluster/my-cluster.yaml
+++ b/streaming/kafka-strimzi/manifests/01-basic-cluster/my-cluster.yaml
@@ -18,7 +18,7 @@ metadata:
   name: my-cluster
 spec:
   kafka:
-    version: 3.4.0
+    version: 3.6.0
     replicas: 3
     template:
       pod:


### PR DESCRIPTION
Following this tutorial https://cloud.google.com/kubernetes-engine/docs/tutorials/apache-kafka-strimzi, I had trouble running this command:
`kubectl get pod,service,deploy,pdb -l=strimzi.io/cluster=my-cluster -n kafka
`
because it showed me this:
`No resources found in kafka namespace.
`
After looking at the yaml file I found this:
```
…
status:
    conditions:
    - lastTransitionTime: "2023-10-24T20:47:04.541547627Z"
      message: 'Unsupported Kafka.spec.kafka.version: 3.4.0. Supported versions are:
        [3.5.0, 3.5.1, 3.6.0]'
      reason: UnsupportedKafkaVersionException
      status: "True"
      type: NotReady
    observedGeneration: 1
…
```
After updating the file with 3.6.0 the tutorial's command works as expected.