### PR TITLE
chore: change scheduling time

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,10 +2,7 @@
   "extends": [
     "config:recommended",
     ":approveMajorUpdates",
-  ],
-  // Create PRs on Monday midnight (UTC)
-  "schedule": [
-    "after 12am on Monday"
+    "schedule:earlyMondays",
   ],
   "minimumReleaseAge": "7 days",
   "vulnerabilityAlerts": {


### PR DESCRIPTION
use the [predefined scheduling][1] to ensure all changes are processed before Monday.

[1]: https://docs.renovatebot.com/presets-schedule/#scheduleweekly