### PR TITLE
Add missing region tags to files used in tutorials

### DIFF
--- a/cost-optimization/gke-scheduled-autoscaler/k8s/scheduled-autoscaler/scheduled-autoscale-example.yaml
+++ b/cost-optimization/gke-scheduled-autoscaler/k8s/scheduled-autoscaler/scheduled-autoscale-example.yaml
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START gke_scheduled_autoscaler_autoscale_example]
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -52,3 +53,4 @@ spec:
               - --value=1
           restartPolicy: OnFailure
       backoffLimit: 1
+# [END gke_scheduled_autoscaler_autoscale_example]

--- a/quickstarts/guestbook/frontend-deployment.yaml
+++ b/quickstarts/guestbook/frontend-deployment.yaml
@@ -43,4 +43,3 @@ spec:
         ports:
         - containerPort: 80
 # [END gke_guestbook_frontend_deployment_deployment_frontend]
----

--- a/quickstarts/guestbook/frontend-service.yaml
+++ b/quickstarts/guestbook/frontend-service.yaml
@@ -30,4 +30,3 @@ spec:
     app: guestbook
     tier: frontend
 # [END gke_guestbook_frontend_service_service_frontend]
----

--- a/quickstarts/guestbook/redis-follower-deployment.yaml
+++ b/quickstarts/guestbook/redis-follower-deployment.yaml
@@ -44,4 +44,3 @@ spec:
         ports:
         - containerPort: 6379
 # [END gke_guestbook_redis_follower_deployment_deployment_redis_follower]
----

--- a/quickstarts/guestbook/redis-follower-service.yaml
+++ b/quickstarts/guestbook/redis-follower-service.yaml
@@ -31,4 +31,3 @@ spec:
     role: follower
     tier: backend
 # [END gke_guestbook_redis_follower_service_service_redis_follower]
----

--- a/quickstarts/guestbook/redis-leader-deployment.yaml
+++ b/quickstarts/guestbook/redis-leader-deployment.yaml
@@ -44,4 +44,3 @@ spec:
         ports:
         - containerPort: 6379
 # [END gke_guestbook_redis_leader_deployment_deployment_redis_leader]
----

--- a/quickstarts/guestbook/redis-leader-service.yaml
+++ b/quickstarts/guestbook/redis-leader-service.yaml
@@ -31,4 +31,3 @@ spec:
     role: leader
     tier: backend
 # [END gke_guestbook_redis_leader_service_service_redis_leader]
----

--- a/quickstarts/hello-app-redis/manifests/pdb-minavailable.yaml
+++ b/quickstarts/hello-app-redis/manifests/pdb-minavailable.yaml
@@ -1,3 +1,18 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_quickstarts_hello_app_redis_manifests_pbd_minavailable]
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -7,3 +22,4 @@ spec:
   selector:
     matchLabels:
       app: redis
+# [END gke_quickstarts_hello_app_redis_manifests_pbd_minavailable]

--- a/quickstarts/hello-app-redis/manifests/roles.sh
+++ b/quickstarts/hello-app-redis/manifests/roles.sh
@@ -1,3 +1,18 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_quickstarts_hello_app_redis_manifests_roles]
 #!/bin/bash
 # Usage: ./roles.sh
 
@@ -11,3 +26,4 @@ done
 
 echo "Executing command: " $command
 $command
+# [END gke_quickstarts_hello_app_redis_manifests_roles]

--- a/quickstarts/languages/dotnet/Dockerfile
+++ b/quickstarts/languages/dotnet/Dockerfile
@@ -1,3 +1,18 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_quickstarts_languages_dotnet_dockerfile]
 # Use Microsoft's official lightweight .NET images.
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /app
@@ -20,3 +35,4 @@ COPY --from=build /app/out .
 
 # Start the .dll (will have the same name as your .csproj file)
 ENTRYPOINT ["dotnet", "helloworld-gke.dll"]
+# [END gke_quickstarts_languages_dotnet_dockerfile]

--- a/quickstarts/languages/dotnet/Program.cs
+++ b/quickstarts/languages/dotnet/Program.cs
@@ -1,17 +1,18 @@
-﻿// Copyright (c) 2019 Google LLC.
-// 
-// Licensed under the Apache License, Version 2.0 (the "License"); you may not
-// use this file except in compliance with the License. You may obtain a copy of
-// the License at
-// 
-// http://www.apache.org/licenses/LICENSE-2.0
-// 
+﻿// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
 // Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-// License for the specific language governing permissions and limitations under
-// the License.
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
+// [START gke_quickstarts_languages_dotnet_program]
 var builder = WebApplication.CreateBuilder(args);
 
 // Google Cloud Run sets the PORT environment variable to tell this
@@ -25,3 +26,4 @@ var app = builder.Build();
 app.MapGet("/", () => $"Hello {target}!");
 
 app.Run(url);
+// [END gke_quickstarts_languages_dotnet_program]

--- a/quickstarts/languages/go/Dockerfile
+++ b/quickstarts/languages/go/Dockerfile
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Use the offical Golang image to create a build artifact.
+# [START gke_quickstarts_languages_go_dockerfile]
+# Use the offical Go image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
 FROM golang:1.21.0 as builder
@@ -40,3 +41,4 @@ COPY --from=builder /quickstart-go /quickstart-go
 # Run the web service on container startup.
 USER nonroot:nonroot
 ENTRYPOINT ["/quickstart-go"]
+# [END gke_quickstarts_languages_go_dockerfile]

--- a/quickstarts/languages/go/helloworld.go
+++ b/quickstarts/languages/go/helloworld.go
@@ -1,3 +1,18 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START gke_quickstarts_languages_go_helloworld]
 package main
 
 import (
@@ -27,3 +42,5 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	}
 	fmt.Fprintf(w, "Hello %s!\n", target)
 }
+
+// [END gke_quickstarts_languages_go_helloworld]

--- a/quickstarts/languages/java/Dockerfile
+++ b/quickstarts/languages/java/Dockerfile
@@ -1,3 +1,18 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_quickstarts_languages_java_dockerfile]
 # Use the official maven/Java 8 image to create a build artifact.
 # https://hub.docker.com/_/maven
 FROM maven:3.5-jdk-8-alpine as builder
@@ -21,3 +36,4 @@ COPY --from=builder /app/target/helloworld-*.jar /helloworld.jar
 
 # Run the web service on container startup.
 CMD ["java","-Djava.security.egd=file:/dev/./urandom","-Dserver.port=${PORT}","-jar","/helloworld.jar"]
+# [END gke_quickstarts_languages_java_dockerfile]

--- a/quickstarts/languages/java/src/main/java/com/example/helloworld/HelloworldApplication.java
+++ b/quickstarts/languages/java/src/main/java/com/example/helloworld/HelloworldApplication.java
@@ -1,3 +1,18 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START gke_quickstarts_languages_java_helloworld]
 package com.example.helloworld;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -24,3 +39,4 @@ public class HelloworldApplication {
 		SpringApplication.run(HelloworldApplication.class, args);
 	}
 }
+// [END gke_quickstarts_languages_java_helloworld]

--- a/quickstarts/languages/nodejs/Dockerfile
+++ b/quickstarts/languages/nodejs/Dockerfile
@@ -1,3 +1,18 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_quickstarts_languages_nodejs_dockerfile]
 # Use the official lightweight Node.js 16 image.
 # https://hub.docker.com/_/node
 FROM node:17-slim
@@ -18,3 +33,4 @@ COPY . ./
 
 # Run the web service on container startup.
 CMD [ "npm", "start" ]
+# [END gke_quickstarts_languages_nodejs_dockerfile]

--- a/quickstarts/languages/nodejs/index.js
+++ b/quickstarts/languages/nodejs/index.js
@@ -1,3 +1,18 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// [START gke_quickstarts_languages_java_index]
 const express = require('express');
 const app = express();
 
@@ -12,3 +27,4 @@ const port = process.env.PORT || 8080;
 app.listen(port, () => {
   console.log('Hello world listening on port', port);
 });
+// [END gke_quickstarts_languages_java_index]

--- a/quickstarts/languages/php/Dockerfile
+++ b/quickstarts/languages/php/Dockerfile
@@ -1,3 +1,18 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_quickstarts_languages_php_dockerfile]
 # Use the official PHP 7.4 image.
 # https://hub.docker.com/_/php
 FROM php:7.4-apache
@@ -13,3 +28,4 @@ RUN sed -i 's/80/${PORT}/g' /etc/apache2/sites-available/000-default.conf /etc/a
 # RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 # https://hub.docker.com/_/php#configuration
 RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
+# [END gke_quickstarts_languages_php_dockerfile]

--- a/quickstarts/languages/php/index.php
+++ b/quickstarts/languages/php/index.php
@@ -1,3 +1,21 @@
+<!--
+Copyright 2019 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<!-- [START gke_quickstarts_languages_php_index] -->
 <?php
 $target = getenv('TARGET', true) ?: 'World';
 echo sprintf("Hello %s!", $target);
+?>
+<!-- [END gke_quickstarts_languages_php_index] -->

--- a/quickstarts/languages/python/Dockerfile
+++ b/quickstarts/languages/python/Dockerfile
@@ -1,3 +1,18 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_quickstarts_languages_python_dockerfile]
 # Use the official lightweight Python image.
 # https://hub.docker.com/_/python
 FROM python:3.7-slim
@@ -15,3 +30,4 @@ RUN pip install Flask gunicorn
 # For environments with multiple CPU cores, increase the number of workers
 # to be equal to the cores available.
 CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 app:app
+# [END gke_quickstarts_languages_python_dockerfile]

--- a/quickstarts/languages/python/app.py
+++ b/quickstarts/languages/python/app.py
@@ -1,3 +1,18 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_quickstarts_languages_python_app]
 import os
 
 from flask import Flask
@@ -11,3 +26,4 @@ def hello_world():
 
 if __name__ == "__main__":
     app.run(debug=True,host='0.0.0.0',port=int(os.environ.get('PORT', 8080)))
+# [END gke_quickstarts_languages_python_app]

--- a/security/language-vulns/maven/deployment.yaml
+++ b/security/language-vulns/maven/deployment.yaml
@@ -12,6 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# [START gke_security_language_vulns_maven_deployment]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -44,4 +46,4 @@ spec:
             memory: "1Gi"
             cpu: "500m"
             ephemeral-storage: "1Gi"
----
+# [END gke_security_language_vulns_maven_deployment]


### PR DESCRIPTION
This PR adds some region tags that were missing from files used in various tutorials. Licence headers have also been retroactively added where missing (in those files that were missing region tags, if applicable).