### PR TITLE
Strimzi operator - Update Kafka versions

### DIFF
--- a/streaming/kafka-strimzi/manifests/02-prometheus-metrics/my-cluster.yaml
+++ b/streaming/kafka-strimzi/manifests/02-prometheus-metrics/my-cluster.yaml
@@ -18,7 +18,7 @@ metadata:
   name: my-cluster
 spec:
   kafka:
-    version: 3.4.0
+    version: 3.6.0
     replicas: 3
     template:
       pod:

--- a/streaming/kafka-strimzi/manifests/03-auth/my-cluster.yaml
+++ b/streaming/kafka-strimzi/manifests/03-auth/my-cluster.yaml
@@ -18,7 +18,7 @@ metadata:
   name: my-cluster
 spec:
   kafka:
-    version: 3.4.0
+    version: 3.6.0
     replicas: 3
     template:
       pod:

--- a/streaming/kafka-strimzi/manifests/04-oauth/my-cluster.yaml
+++ b/streaming/kafka-strimzi/manifests/04-oauth/my-cluster.yaml
@@ -18,7 +18,7 @@ metadata:
   name: my-cluster
 spec:
   kafka:
-    version: 3.4.0
+    version: 3.6.0
     replicas: 3
     template:
       pod:

--- a/streaming/kafka-strimzi/manifests/05-ssl-options/my-cluster-own-CA.yaml
+++ b/streaming/kafka-strimzi/manifests/05-ssl-options/my-cluster-own-CA.yaml
@@ -18,7 +18,7 @@ metadata:
   name: my-cluster
 spec:
   kafka:
-    version: 3.4.0
+    version: 3.6.0
     replicas: 3
     template:
       pod:

--- a/streaming/kafka-strimzi/manifests/05-ssl-options/my-cluster-own-listener-cert.yaml
+++ b/streaming/kafka-strimzi/manifests/05-ssl-options/my-cluster-own-listener-cert.yaml
@@ -18,7 +18,7 @@ metadata:
   name: my-cluster
 spec:
   kafka:
-    version: 3.4.0
+    version: 3.6.0
     replicas: 3
     template:
       pod:

--- a/streaming/kafka-strimzi/manifests/06-kraft-experimental/my-cluster.yaml
+++ b/streaming/kafka-strimzi/manifests/06-kraft-experimental/my-cluster.yaml
@@ -18,7 +18,7 @@ metadata:
   name: my-cluster
 spec:
   kafka:
-    version: 3.4.0
+    version: 3.6.0
     replicas: 3
     template:
       pod:

--- a/streaming/kafka-strimzi/manifests/07-backup-restore/my-source-cluster.yaml
+++ b/streaming/kafka-strimzi/manifests/07-backup-restore/my-source-cluster.yaml
@@ -18,7 +18,7 @@ metadata:
   name: my-source-cluster
 spec:
   kafka:
-    version: 3.4.0
+    version: 3.6.0
     replicas: 3
     template:
       pod:

--- a/streaming/kafka-strimzi/manifests/07-backup-restore/my-target-cluster.yaml
+++ b/streaming/kafka-strimzi/manifests/07-backup-restore/my-target-cluster.yaml
@@ -18,7 +18,7 @@ metadata:
   name: my-target-cluster
 spec:
   kafka:
-    version: 3.4.0
+    version: 3.6.0
     replicas: 3
     template:
       pod:

--- a/streaming/kafka-strimzi/manifests/08-regional-pd/my-cluster.yaml
+++ b/streaming/kafka-strimzi/manifests/08-regional-pd/my-cluster.yaml
@@ -18,7 +18,7 @@ metadata:
   name: my-cluster
 spec:
   kafka:
-    version: 3.4.0
+    version: 3.6.0
     replicas: 3
     template:
       pod:

--- a/streaming/kafka-strimzi/manifests/09-mirror-maker/my-source-cluster.yaml
+++ b/streaming/kafka-strimzi/manifests/09-mirror-maker/my-source-cluster.yaml
@@ -18,7 +18,7 @@ metadata:
   name: my-source-cluster
 spec:
   kafka:
-    version: 3.4.0
+    version: 3.6.0
     replicas: 3
     template:
       pod:

--- a/streaming/kafka-strimzi/manifests/09-mirror-maker/my-target-cluster.yaml
+++ b/streaming/kafka-strimzi/manifests/09-mirror-maker/my-target-cluster.yaml
@@ -18,7 +18,7 @@ metadata:
   name: my-target-cluster
 spec:
   kafka:
-    version: 3.4.0
+    version: 3.6.0
     replicas: 3
     template:
       pod:


### PR DESCRIPTION
The basic cluster version [was changed](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/commit/26c40bafdf9dcf05a84535a3e7ece6014e828360), but all other yamls left unupdated and it brokes almost all Strimzi documentation. Use the same versions for all Kafka manifests.