### PR TITLE
Strimzi, Confluent, Spotahome - update TF module versions

### DIFF
--- a/.github/workflows/databases-ci.yml
+++ b/.github/workflows/databases-ci.yml
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: databases-ci.yml
 on:
   push:

--- a/databases/redis-spotahome/terraform/gke-autopilot/variables.tf
+++ b/databases/redis-spotahome/terraform/gke-autopilot/variables.tf
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 variable "project_id" {
   description = "The project ID to host the cluster in"
   default     = ""

--- a/databases/redis-spotahome/terraform/gke-autopilot/versions.tf
+++ b/databases/redis-spotahome/terraform/gke-autopilot/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
   required_version = ">= 0.13"

--- a/databases/redis-spotahome/terraform/gke-autopilot/versions.tf
+++ b/databases/redis-spotahome/terraform/gke-autopilot/versions.tf
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 terraform {
   required_providers {
     google = {

--- a/databases/redis-spotahome/terraform/gke-autopilot/versions.tf
+++ b/databases/redis-spotahome/terraform/gke-autopilot/versions.tf
@@ -19,5 +19,5 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.3"
 }

--- a/databases/redis-spotahome/terraform/gke-standard/variables.tf
+++ b/databases/redis-spotahome/terraform/gke-standard/variables.tf
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 variable "project_id" {
   description = "The project ID to host the cluster in"
   default     = ""

--- a/databases/redis-spotahome/terraform/gke-standard/versions.tf
+++ b/databases/redis-spotahome/terraform/gke-standard/versions.tf
@@ -1,8 +1,22 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
   required_version = ">= 0.13"

--- a/databases/redis-spotahome/terraform/gke-standard/versions.tf
+++ b/databases/redis-spotahome/terraform/gke-standard/versions.tf
@@ -19,5 +19,5 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.3"
 }

--- a/databases/redis-spotahome/terraform/modules/cluster-autopilot/main.tf
+++ b/databases/redis-spotahome/terraform/modules/cluster-autopilot/main.tf
@@ -15,6 +15,7 @@
 # [START gke_redis_spotahome_autopilot_private_regional_cluster]
 module "redis_cluster" {
   source                   = "terraform-google-modules/kubernetes-engine/google//modules/beta-autopilot-private-cluster"
+  version                  = "~> 29.0"
   project_id               = var.project_id
   name                     = "${var.cluster_prefix}-cluster"
   regional                 = true

--- a/databases/redis-spotahome/terraform/modules/cluster-autopilot/variables.tf
+++ b/databases/redis-spotahome/terraform/modules/cluster-autopilot/variables.tf
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 variable "project_id" {
   description = "The project ID to host the cluster in"
 }

--- a/databases/redis-spotahome/terraform/modules/cluster-autopilot/versions.tf
+++ b/databases/redis-spotahome/terraform/modules/cluster-autopilot/versions.tf
@@ -1,8 +1,22 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
   required_version = ">= 0.13"

--- a/databases/redis-spotahome/terraform/modules/cluster-autopilot/versions.tf
+++ b/databases/redis-spotahome/terraform/modules/cluster-autopilot/versions.tf
@@ -19,5 +19,5 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.3"
 }

--- a/databases/redis-spotahome/terraform/modules/cluster/main.tf
+++ b/databases/redis-spotahome/terraform/modules/cluster/main.tf
@@ -15,6 +15,7 @@
 # [START gke_redis_spotahome_standard_private_regional_cluster]
 module "redis_cluster" {
   source                   = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
+  version                  = "~> 29.0"
   project_id               = var.project_id
   name                     = "${var.cluster_prefix}-cluster"
   regional                 = true

--- a/databases/redis-spotahome/terraform/modules/cluster/versions.tf
+++ b/databases/redis-spotahome/terraform/modules/cluster/versions.tf
@@ -1,8 +1,22 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
   required_version = ">= 0.13"

--- a/databases/redis-spotahome/terraform/modules/cluster/versions.tf
+++ b/databases/redis-spotahome/terraform/modules/cluster/versions.tf
@@ -19,5 +19,5 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.3"
 }

--- a/databases/redis-spotahome/terraform/modules/network/main.tf
+++ b/databases/redis-spotahome/terraform/modules/network/main.tf
@@ -15,7 +15,7 @@
 # [START gke_redis_spotahome_vpc_multi_region_network]
 module "gcp-network" {
   source  = "terraform-google-modules/network/google"
-  version = "< 8.0.0"
+  version = "~> 8.0"
 
   project_id   = var.project_id
   network_name = "${var.cluster_prefix}-vpc"

--- a/databases/redis-spotahome/terraform/modules/network/variables.tf
+++ b/databases/redis-spotahome/terraform/modules/network/variables.tf
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 variable "project_id" {
   description = "The project ID to host the cluster in"
 }

--- a/databases/redis-spotahome/terraform/modules/network/versions.tf
+++ b/databases/redis-spotahome/terraform/modules/network/versions.tf
@@ -1,8 +1,22 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
   required_version = ">= 0.13"

--- a/databases/redis-spotahome/terraform/modules/network/versions.tf
+++ b/databases/redis-spotahome/terraform/modules/network/versions.tf
@@ -19,5 +19,5 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.3"
 }

--- a/databases/redis/terraform/gke-replication/variables.tf
+++ b/databases/redis/terraform/gke-replication/variables.tf
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 variable "project_id" {
   description = "The project ID to host the cluster in"
   default     = ""

--- a/databases/redis/terraform/gke-replication/versions.tf
+++ b/databases/redis/terraform/gke-replication/versions.tf
@@ -1,8 +1,22 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
   required_version = ">= 0.13"

--- a/databases/redis/terraform/modules/cluster-replication/main.tf
+++ b/databases/redis/terraform/modules/cluster-replication/main.tf
@@ -15,6 +15,7 @@
 # [START gke_redis_standard_private_regional_cluster]
 module "redis_cluster" {
   source                   = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
+  version                  = "~> 29.0"
   project_id               = var.project_id
   name                     = "${var.cluster_prefix}-cluster"
   regional                 = true

--- a/databases/redis/terraform/modules/cluster-replication/variables.tf
+++ b/databases/redis/terraform/modules/cluster-replication/variables.tf
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 variable "project_id" {
   description = "The project ID to host the cluster in"
 }

--- a/databases/redis/terraform/modules/cluster-replication/versions.tf
+++ b/databases/redis/terraform/modules/cluster-replication/versions.tf
@@ -1,8 +1,22 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
   required_version = ">= 0.13"

--- a/databases/redis/terraform/modules/network-replication/main.tf
+++ b/databases/redis/terraform/modules/network-replication/main.tf
@@ -15,7 +15,7 @@
 # [START gke_redis_vpc_multi_region_network]
 module "gcp-network" {
   source  = "terraform-google-modules/network/google"
-  version = "< 8.0.0"
+  version = "~> 8.0"
 
   project_id   = var.project_id
   network_name = "${var.cluster_prefix}-vpc"

--- a/databases/redis/terraform/modules/network-replication/variables.tf
+++ b/databases/redis/terraform/modules/network-replication/variables.tf
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 variable "project_id" {
   description = "The project ID to host the cluster in"
 }

--- a/databases/redis/terraform/modules/network-replication/versions.tf
+++ b/databases/redis/terraform/modules/network-replication/versions.tf
@@ -1,8 +1,22 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
   }
   required_version = ">= 0.13"

--- a/streaming/kafka/terraform/gke-autopilot/variables.tf
+++ b/streaming/kafka/terraform/gke-autopilot/variables.tf
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 variable "project_id" {
   description = "The project ID to host the cluster in"
   default     = ""

--- a/streaming/kafka/terraform/gke-autopilot/versions.tf
+++ b/streaming/kafka/terraform/gke-autopilot/versions.tf
@@ -1,8 +1,22 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "< 5.0" # upgrade to ~> 5.0 *AFTER* terraform-google-network module is updated (https://github.com/terraform-google-modules/terraform-google-network/pull/506)
+      version = "~> 5.0"
     }
   }
   required_version = ">= 0.13"

--- a/streaming/kafka/terraform/gke-autopilot/versions.tf
+++ b/streaming/kafka/terraform/gke-autopilot/versions.tf
@@ -19,5 +19,5 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.3"
 }

--- a/streaming/kafka/terraform/gke-replication/variables.tf
+++ b/streaming/kafka/terraform/gke-replication/variables.tf
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 variable "project_id" {
   description = "The project ID to host the cluster in"
   default     = ""

--- a/streaming/kafka/terraform/gke-replication/versions.tf
+++ b/streaming/kafka/terraform/gke-replication/versions.tf
@@ -1,8 +1,22 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "< 5.0" # upgrade to ~> 5.0 *AFTER* terraform-google-network module is updated (https://github.com/terraform-google-modules/terraform-google-network/pull/506)
+      version = "~> 5.0"
     }
   }
   required_version = ">= 0.13"

--- a/streaming/kafka/terraform/gke-replication/versions.tf
+++ b/streaming/kafka/terraform/gke-replication/versions.tf
@@ -19,5 +19,5 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.3"
 }

--- a/streaming/kafka/terraform/gke-standard/variables.tf
+++ b/streaming/kafka/terraform/gke-standard/variables.tf
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 variable "project_id" {
   description = "The project ID to host the cluster in"
   default     = ""

--- a/streaming/kafka/terraform/gke-standard/versions.tf
+++ b/streaming/kafka/terraform/gke-standard/versions.tf
@@ -1,8 +1,22 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "< 5.0" # upgrade to ~> 5.0 *AFTER* terraform-google-network module is updated (https://github.com/terraform-google-modules/terraform-google-network/pull/506)
+      version = "~> 5.0"
     }
   }
   required_version = ">= 0.13"

--- a/streaming/kafka/terraform/gke-standard/versions.tf
+++ b/streaming/kafka/terraform/gke-standard/versions.tf
@@ -19,5 +19,5 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.3"
 }

--- a/streaming/kafka/terraform/modules/cluster-autopilot/main.tf
+++ b/streaming/kafka/terraform/modules/cluster-autopilot/main.tf
@@ -15,6 +15,7 @@
 # [START gke_streaming_kafka_autopilot_private_regional_cluster]
 module "kafka_cluster" {
   source                   = "terraform-google-modules/kubernetes-engine/google//modules/beta-autopilot-private-cluster"
+  version                  = "~> 29.0"
   project_id               = var.project_id
   name                     = "${var.cluster_prefix}-cluster"
   regional                 = true

--- a/streaming/kafka/terraform/modules/cluster-autopilot/variables.tf
+++ b/streaming/kafka/terraform/modules/cluster-autopilot/variables.tf
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 variable "project_id" {
   description = "The project ID to host the cluster in"
 }

--- a/streaming/kafka/terraform/modules/cluster-autopilot/versions.tf
+++ b/streaming/kafka/terraform/modules/cluster-autopilot/versions.tf
@@ -1,8 +1,22 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "< 5.0" # upgrade to ~> 5.0 *AFTER* terraform-google-network module is updated (https://github.com/terraform-google-modules/terraform-google-network/pull/506)
+      version = "~> 5.0"
     }
   }
   required_version = ">= 0.13"

--- a/streaming/kafka/terraform/modules/cluster-autopilot/versions.tf
+++ b/streaming/kafka/terraform/modules/cluster-autopilot/versions.tf
@@ -19,5 +19,5 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.3"
 }

--- a/streaming/kafka/terraform/modules/cluster-replication/main.tf
+++ b/streaming/kafka/terraform/modules/cluster-replication/main.tf
@@ -15,6 +15,7 @@
 # [START gke_streaming_kafka_standard_private_regional_cluster]
 module "kafka_cluster" {
   source                   = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
+  version                  = "~> 29.0"
   project_id               = var.project_id
   name                     = "${var.cluster_prefix}-cluster"
   regional                 = true

--- a/streaming/kafka/terraform/modules/cluster-replication/variables.tf
+++ b/streaming/kafka/terraform/modules/cluster-replication/variables.tf
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 variable "project_id" {
   description = "The project ID to host the cluster in"
 }

--- a/streaming/kafka/terraform/modules/cluster-replication/versions.tf
+++ b/streaming/kafka/terraform/modules/cluster-replication/versions.tf
@@ -1,8 +1,22 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "< 5.0" # upgrade to ~> 5.0 *AFTER* terraform-google-network module is updated (https://github.com/terraform-google-modules/terraform-google-network/pull/506)
+      version = "~> 5.0"
     }
   }
   required_version = ">= 0.13"

--- a/streaming/kafka/terraform/modules/cluster-replication/versions.tf
+++ b/streaming/kafka/terraform/modules/cluster-replication/versions.tf
@@ -19,5 +19,5 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.3"
 }

--- a/streaming/kafka/terraform/modules/cluster/main.tf
+++ b/streaming/kafka/terraform/modules/cluster/main.tf
@@ -15,6 +15,7 @@
 # [START gke_streaming_kafka_standard_private_regional_cluster]
 module "kafka_cluster" {
   source                   = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
+  version                  = "~> 29.0"
   project_id               = var.project_id
   name                     = "${var.cluster_prefix}-cluster"
   regional                 = true

--- a/streaming/kafka/terraform/modules/cluster/variables.tf
+++ b/streaming/kafka/terraform/modules/cluster/variables.tf
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 variable "project_id" {
   description = "The project ID to host the cluster in"
 }

--- a/streaming/kafka/terraform/modules/cluster/versions.tf
+++ b/streaming/kafka/terraform/modules/cluster/versions.tf
@@ -1,8 +1,22 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "< 5.0" # upgrade to ~> 5.0 *AFTER* terraform-google-network module is updated (https://github.com/terraform-google-modules/terraform-google-network/pull/506)
+      version = "~> 5.0"
     }
   }
   required_version = ">= 0.13"

--- a/streaming/kafka/terraform/modules/cluster/versions.tf
+++ b/streaming/kafka/terraform/modules/cluster/versions.tf
@@ -19,5 +19,5 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.3"
 }

--- a/streaming/kafka/terraform/modules/network-replication/main.tf
+++ b/streaming/kafka/terraform/modules/network-replication/main.tf
@@ -15,7 +15,7 @@
 # [START gke_streaming_kafka_vpc_multi_region_network]
 module "gcp-network" {
   source  = "terraform-google-modules/network/google"
-  version = "< 8.0.0"
+  version = "~> 8.0"
 
   project_id   = var.project_id
   network_name = "${var.cluster_prefix}-vpc"

--- a/streaming/kafka/terraform/modules/network-replication/variables.tf
+++ b/streaming/kafka/terraform/modules/network-replication/variables.tf
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 variable "project_id" {
   description = "The project ID to host the cluster in"
 }

--- a/streaming/kafka/terraform/modules/network-replication/versions.tf
+++ b/streaming/kafka/terraform/modules/network-replication/versions.tf
@@ -1,8 +1,22 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "< 5.0" # upgrade to ~> 5.0 *AFTER* terraform-google-network module is updated (https://github.com/terraform-google-modules/terraform-google-network/pull/506)
+      version = "~> 5.0"
     }
   }
   required_version = ">= 0.13"

--- a/streaming/kafka/terraform/modules/network-replication/versions.tf
+++ b/streaming/kafka/terraform/modules/network-replication/versions.tf
@@ -19,5 +19,5 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.3"
 }

--- a/streaming/kafka/terraform/modules/network/main.tf
+++ b/streaming/kafka/terraform/modules/network/main.tf
@@ -15,7 +15,7 @@
 # [START gke_streaming_kafka_vpc_multi_region_network]
 module "gcp-network" {
   source  = "terraform-google-modules/network/google"
-  version = "< 8.0.0"
+  version = "~> 8.0"
 
   project_id   = var.project_id
   network_name = "${var.cluster_prefix}-vpc"

--- a/streaming/kafka/terraform/modules/network/variables.tf
+++ b/streaming/kafka/terraform/modules/network/variables.tf
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 variable "project_id" {
   description = "The project ID to host the cluster in"
 }

--- a/streaming/kafka/terraform/modules/network/versions.tf
+++ b/streaming/kafka/terraform/modules/network/versions.tf
@@ -1,8 +1,22 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "< 5.0" # upgrade to ~> 5.0 *AFTER* terraform-google-network module is updated (https://github.com/terraform-google-modules/terraform-google-network/pull/506)
+      version = "~> 5.0"
     }
   }
   required_version = ">= 0.13"

--- a/streaming/kafka/terraform/modules/network/versions.tf
+++ b/streaming/kafka/terraform/modules/network/versions.tf
@@ -19,5 +19,5 @@ terraform {
       version = "~> 5.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.3"
 }


### PR DESCRIPTION
Update Google provider version 4.x -> 5.x and fix modules version constraints.