### PR TITLE
feat: Add LLM samples for multi-gpu and multi-tpu tutorials

### DIFF
--- a/ai-ml/llm-multihost-tpus-saxml/README.md
+++ b/ai-ml/llm-multihost-tpus-saxml/README.md
@@ -1,0 +1,9 @@
+# Serve an LLM using multi-host TPUs on GKE with Saxml samples
+
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/kubernetes-engine-samples&cloudshell_tutorial=README.md&cloudshell_workspace=ai-ml/llm-multihost-tpus-saxml)
+
+This example shows how to serve an LLM using multi-host TPUs on
+[Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine).
+
+Visit https://cloud.google.com/kubernetes-engine/docs/tutorials/tpu-multihost-saxml
+to follow the tutorial.

--- a/ai-ml/llm-multihost-tpus-saxml/sax-admin-server.yaml
+++ b/ai-ml/llm-multihost-tpus-saxml/sax-admin-server.yaml
@@ -1,0 +1,42 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_aiml_llm_multihost_tpus_saxml_admin_server]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sax-admin-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sax-admin-server
+  template:
+    metadata:
+      labels:
+        app: sax-admin-server
+    spec:
+      hostNetwork: false
+      serviceAccountName: sax-sa
+      containers:
+      - name: sax-admin-server
+        image: us-docker.pkg.dev/cloud-tpu-images/inference/sax-admin-server:v1.1.0
+        securityContext:
+          privileged: true
+        ports:
+        - containerPort: 10000
+        env:
+        - name: GSBUCKET
+          value: BUCKET_NAME
+# [END gke_aiml_llm_multihost_tpus_saxml_admin_server]

--- a/ai-ml/llm-multihost-tpus-saxml/sax-http.yaml
+++ b/ai-ml/llm-multihost-tpus-saxml/sax-http.yaml
@@ -1,0 +1,53 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_aiml_llm_multihost_tpus_saxml_http]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sax-http
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sax-http
+  template:
+    metadata:
+      labels:
+        app: sax-http
+    spec:
+      hostNetwork: false
+      serviceAccountName: sax-sa
+      containers:
+      - name: sax-http
+        image: us-docker.pkg.dev/cloud-tpu-images/inference/sax-http:v1.0.0
+        ports:
+        - containerPort: 8888
+        env:
+        - name: SAX_ROOT
+          value: "gs://BUCKET_NAME/sax-root"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sax-http-lb
+spec:
+  selector:
+    app: sax-http
+  ports:
+  - protocol: TCP
+    port: 8888
+    targetPort: 8888
+  type: LoadBalancer
+# [END gke_aiml_llm_multihost_tpus_saxml_http]

--- a/ai-ml/llm-multihost-tpus-saxml/sax-model-server-set.yaml
+++ b/ai-ml/llm-multihost-tpus-saxml/sax-model-server-set.yaml
@@ -1,0 +1,60 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_aiml_llm_multihost_tpus_saxml_model_server]
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: sax-model-server-set
+  annotations:
+    alpha.jobset.sigs.k8s.io/exclusive-topology: cloud.google.com/gke-nodepool
+spec:
+  failurePolicy:
+    maxRestarts: 4
+  replicatedJobs:
+    - name: sax-model-server
+      replicas: 2
+      template:
+        spec:
+          parallelism: 8
+          completions: 8
+          backoffLimit: 0
+          template:
+            spec:
+              serviceAccountName: sax-sa
+              hostNetwork: true
+              dnsPolicy: ClusterFirstWithHostNet
+              nodeSelector:
+                cloud.google.com/gke-tpu-accelerator: tpu-v5-lite-podslice
+                cloud.google.com/gke-tpu-topology: 4x8
+              containers:
+              - name: sax-model-server
+                image: us-docker.pkg.dev/cloud-tpu-images/inference/sax-model-server:v1.1.0
+                args: ["--port=10001","--sax_cell=/sax/test", "--platform_chip=tpuv5e"]
+                ports:
+                - containerPort: 10001
+                - containerPort: 8471
+                securityContext:
+                  privileged: true
+                env:
+                - name: SAX_ROOT
+                  value: "gs://BUCKET_NAME/sax-root"
+                - name: MEGASCALE_NUM_SLICES
+                  value: ""
+                resources:
+                  requests:
+                    google.com/tpu: 4
+                  limits:
+                    google.com/tpu: 4
+# [END gke_aiml_llm_multihost_tpus_saxml_model_server]

--- a/ai-ml/llm-multiple-gpus/README.md
+++ b/ai-ml/llm-multiple-gpus/README.md
@@ -1,0 +1,9 @@
+# Serve an LLM with multiple GPUs in GKE samples
+
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/kubernetes-engine-samples&cloudshell_tutorial=README.md&cloudshell_workspace=ai-ml/llm-multiple-gpus)
+
+This example shows how to serve an LLM with multiple GPUs using
+[Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine).
+
+Visit https://cloud.google.com/kubernetes-engine/docs/tutorials/serve-multiple-gpu
+to follow the tutorial.

--- a/ai-ml/llm-multiple-gpus/falcon-40b/gradio.yaml
+++ b/ai-ml/llm-multiple-gpus/falcon-40b/gradio.yaml
@@ -1,0 +1,60 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_aiml_llm_multi_gpus_falcon_40b_gradio]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gradio
+spec:
+  selector:
+    matchLabels:
+      app: gradio
+  template:
+    metadata:
+      labels:
+        app: gradio
+    spec:
+      containers:
+      - name: gradio
+        image: us-docker.pkg.dev/google-samples/containers/gke/gradio:v0.0.6
+        env:
+          - name: MODEL_URL
+            value: "http://llm-service"
+          - name: MODEL
+            value: "falcon-40b"
+          - name: MAX_TOKENS
+            value: "400"
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "250m"
+          limits:
+            memory: "256Mi"
+            cpu: "500m"
+        ports:
+        - containerPort: 7860
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gradio-service
+spec:
+  type: LoadBalancer
+  selector:
+    app: gradio
+  ports:
+  - port: 80
+    targetPort: 7860
+# [END gke_aiml_llm_multi_gpus_falcon_40b_gradio]

--- a/ai-ml/llm-multiple-gpus/falcon-40b/text-generation-inference.yaml
+++ b/ai-ml/llm-multiple-gpus/falcon-40b/text-generation-inference.yaml
@@ -1,0 +1,60 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_aiml_llm_multi_gpus_falcon_40b_inference]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: llm
+  template:
+    metadata:
+      labels:
+        app: llm
+    spec:
+      containers:
+      - name: llm
+        image: ghcr.io/huggingface/text-generation-inference:1.1.0
+        resources:
+          limits:
+            nvidia.com/gpu: "2"
+        env:
+        - name: MODEL_ID
+          value: tiiuae/falcon-40b-instruct
+        - name: NUM_SHARD
+          value: "2"
+        - name: PORT
+          value: "8080"
+        - name: QUANTIZE
+          value: bitsandbytes-nf4
+        volumeMounts:
+          - mountPath: /dev/shm
+            name: dshm
+          - mountPath: /data
+            name: data
+      volumes:
+        - name: dshm
+          emptyDir:
+              medium: Memory
+        - name: data
+          emptyDir: {}
+      nodeSelector:
+        cloud.google.com/gke-accelerator: nvidia-l4
+        cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
+        cloud.google.com/gke-spot: "true"
+# [END gke_aiml_llm_multi_gpus_falcon_40b_inference]

--- a/ai-ml/llm-multiple-gpus/llama2-70b/gradio.yaml
+++ b/ai-ml/llm-multiple-gpus/llama2-70b/gradio.yaml
@@ -1,0 +1,60 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_aiml_llm_multi_gpus_llama2_70b_gradio]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gradio
+spec:
+  selector:
+    matchLabels:
+      app: gradio
+  template:
+    metadata:
+      labels:
+        app: gradio
+    spec:
+      containers:
+      - name: gradio
+        image: us-docker.pkg.dev/google-samples/containers/gke/gradio:v0.0.6
+        env:
+          - name: MODEL_URL
+            value: "http://llm-service"
+          - name: MODEL
+            value: "llama-2-70b"
+          - name: MAX_TOKENS
+            value: "400"
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "250m"
+          limits:
+            memory: "256Mi"
+            cpu: "500m"
+        ports:
+        - containerPort: 7860
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gradio-service
+spec:
+  type: LoadBalancer
+  selector:
+    app: gradio
+  ports:
+  - port: 80
+    targetPort: 7860
+# [END gke_aiml_llm_multi_gpus_llama2_70b_gradio]

--- a/ai-ml/llm-multiple-gpus/llama2-70b/text-generation-inference.yaml
+++ b/ai-ml/llm-multiple-gpus/llama2-70b/text-generation-inference.yaml
@@ -1,0 +1,65 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_aiml_llm_multi_gpus_llama2_70b_inference]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: llm
+  template:
+    metadata:
+      labels:
+        app: llm
+    spec:
+      containers:
+      - name: llm
+        image: ghcr.io/huggingface/text-generation-inference:1.1.0
+        resources:
+          limits:
+            nvidia.com/gpu: "2"
+        env:
+        - name: MODEL_ID
+          value: meta-llama/Llama-2-70b-chat-hf
+        - name: NUM_SHARD
+          value: "2"
+        - name: PORT
+          value: "8080"
+        - name: QUANTIZE
+          value: bitsandbytes-nf4
+        - name: HUGGING_FACE_HUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: l4-demo
+              key: HUGGING_FACE_TOKEN
+        volumeMounts:
+          - mountPath: /dev/shm
+            name: dshm
+          - mountPath: /data
+            name: data
+      volumes:
+        - name: dshm
+          emptyDir:
+              medium: Memory
+        - name: data
+          emptyDir: {}
+      nodeSelector:
+        cloud.google.com/gke-accelerator: nvidia-l4
+        cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
+        cloud.google.com/gke-spot: "true"
+# [END gke_aiml_llm_multi_gpus_llama2_70b_inference]

--- a/ai-ml/llm-multiple-gpus/llm-service.yaml
+++ b/ai-ml/llm-multiple-gpus/llm-service.yaml
@@ -1,0 +1,28 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_aiml_llm_multi_gpus_service]
+apiVersion: v1
+kind: Service
+metadata:
+  name: llm-service
+spec:
+  selector:
+    app: llm
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080
+# [END gke_aiml_llm_multi_gpus_service]


### PR DESCRIPTION
This PR adds samples for the following two tutorials:
- https://cloud.google.com/kubernetes-engine/docs/tutorials/serve-multiple-gpu
- https://cloud.google.com/kubernetes-engine/docs/tutorials/tpu-multihost-saxml