### PR TITLE
fix: Update manifest to use L4 GPUs instead

### DIFF
--- a/ai-ml/t5-model-serving/kubernetes/serving-gpu.yaml
+++ b/ai-ml/t5-model-serving/kubernetes/serving-gpu.yaml
@@ -36,7 +36,7 @@ spec:
         machine: gpu
     spec:
       nodeSelector:
-        cloud.google.com/gke-accelerator: nvidia-tesla-t4
+        cloud.google.com/gke-accelerator: nvidia-l4
       securityContext:
         fsGroup: 1000
         runAsUser: 1000


### PR DESCRIPTION
We're modifying the tutorial to use L4 GPUs. I edited the one nodeSelector that I could see. Resource requests etc are still within Autopilot limits for L4