### PR TITLE
Replace missing "es" language with "fr"

### DIFF
--- a/ai-ml/t5-model-serving/kubernetes/loadgenerator.yaml
+++ b/ai-ml/t5-model-serving/kubernetes/loadgenerator.yaml
@@ -34,7 +34,7 @@ data:
             self.payload = {
                 "text": "this is a test sentence",
                 "from": "en",
-                "to": "es"
+                "to": "fr"
             }
 
         @task()


### PR DESCRIPTION
The loadgenerator here refers to a language key "es" which is not available per the model specifics: https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/ai-ml/t5-model-serving/model/handler.py#L27

Update either here to "fr" or some other supported language, or add Spanish "es" to the model.