### PR TITLE
Changed to bucketName: $GSBUCKET for Triton and TFServing deployment manifests.

### DIFF
--- a/ai-ml/gke-online-serving-single-gpu/src/gke-config/deployment-tfserve.yaml
+++ b/ai-ml/gke-online-serving-single-gpu/src/gke-config/deployment-tfserve.yaml
@@ -63,6 +63,6 @@ spec:
           driver: gcsfuse.csi.storage.gke.io
           readOnly: false
           volumeAttributes:
-            bucketName: $BUCKET_NAME
+            bucketName: $GSBUCKET
             mountOptions: "implicit-dirs"
         

--- a/ai-ml/gke-online-serving-single-gpu/src/gke-config/deployment-triton.yaml
+++ b/ai-ml/gke-online-serving-single-gpu/src/gke-config/deployment-triton.yaml
@@ -65,6 +65,6 @@ spec:
           driver: gcsfuse.csi.storage.gke.io
           readOnly: false
           volumeAttributes:
-            bucketName: $BUCKET_NAME
+            bucketName: $GSBUCKET
             mountOptions: "implicit-dirs"
         


### PR DESCRIPTION
Changed to bucketName: $GSBUCKET for Triton and TFServing deployment manifests.

Fixes #1069