### PR TITLE
Add Ray on GKE llm examples

### DIFF
--- a/.github/workflows/ai-ml-gke-ray-ci.yml
+++ b/.github/workflows/ai-ml-gke-ray-ci.yml
@@ -5,11 +5,11 @@ on:
       - main
     paths:
       - '.github/workflows/ai-ml-gke-ray-ci.yml'
-      - 'ai-ml/gke-ray/gke-platform/**'
+      - 'ai-ml/gke-ray/**'
   pull_request:
     paths:
       - '.github/workflows/ai-ml-gke-ray-ci.yml'
-      - 'ai-ml/gke-ray/gke-platform/**'
+      - 'ai-ml/gke-ray/**'
 jobs:
   job:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ai-ml-gke-ray-ci.yml
+++ b/.github/workflows/ai-ml-gke-ray-ci.yml
@@ -1,0 +1,22 @@
+name: ai-ml-gke-ray-ci
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/ai-ml-gke-ray-ci.yml'
+      - 'ai-ml/gke-ray/gke-platform/**'
+  pull_request:
+    paths:
+      - '.github/workflows/ai-ml-gke-ray-ci.yml'
+      - 'ai-ml/gke-ray/gke-platform/**'
+jobs:
+  job:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate terraform
+        run: |
+          cd ai-ml/gke-ray/gke-platform
+          terraform init
+          terraform validate

--- a/ai-ml/gke-ray/gke-platform/.gitignore
+++ b/ai-ml/gke-ray/gke-platform/.gitignore
@@ -1,0 +1,5 @@
+**/.terraform/*
+*.tfstate
+*.tfstate.*
+*.tfvars
+*.tfvars.json

--- a/ai-ml/gke-ray/gke-platform/README.md
+++ b/ai-ml/gke-ray/gke-platform/README.md
@@ -1,0 +1,31 @@
+# Ray on GKE
+
+This repository contains a Terraform template for installing a Standard or Autopilot GKE cluster in your GCP project.
+It sets up the cluster to work seamlessly with the `ray-on-gke`
+
+Platform resources:
+* GKE Cluster
+* Nvidia GPU drivers
+* Kuberay operator and CRDs
+
+## Installation
+
+Preinstall the following on your computer:
+* Kubectl
+* Terraform 
+* Helm
+* Gcloud
+
+> **_NOTE:_** Terraform keeps state metadata in a local file called `terraform.tfstate`. Deleting the file may cause some resources to not be cleaned up correctly even if you delete the cluster. We suggest using `terraform destory` before reapplying/reinstalling.
+
+### Platform
+
+1. If needed, git clone this repo
+
+2. `cd kubernetes-engine-samples/ai-ml/gke-ray/gke-platform`
+
+3. Edit `variables.tf` with your Google Cloud settings or `terraform.tfvars` with desired configurations.
+
+4. Run `terraform init`
+
+5. Run `terraform apply`

--- a/ai-ml/gke-ray/gke-platform/main.tf
+++ b/ai-ml/gke-ray/gke-platform/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/gke-platform/main.tf
+++ b/ai-ml/gke-ray/gke-platform/main.tf
@@ -1,0 +1,102 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data "google_client_config" "provider" {}
+
+data "google_container_cluster" "ml_cluster" {
+  name       = var.cluster_name
+  location   = var.region
+  depends_on = [module.gke_autopilot, module.gke_standard]
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "kubernetes" {
+  host  = data.google_container_cluster.ml_cluster.endpoint
+  token = data.google_client_config.provider.access_token
+  cluster_ca_certificate = base64decode(
+    data.google_container_cluster.ml_cluster.master_auth[0].cluster_ca_certificate
+  )
+}
+
+provider "kubectl" {
+  host  = data.google_container_cluster.ml_cluster.endpoint
+  token = data.google_client_config.provider.access_token
+  cluster_ca_certificate = base64decode(
+    data.google_container_cluster.ml_cluster.master_auth[0].cluster_ca_certificate
+  )
+}
+
+provider "helm" {
+  kubernetes {
+    ##config_path = pathexpand("~/.kube/config")
+    host  = data.google_container_cluster.ml_cluster.endpoint
+    token = data.google_client_config.provider.access_token
+    cluster_ca_certificate = base64decode(
+      data.google_container_cluster.ml_cluster.master_auth[0].cluster_ca_certificate
+    )
+  }
+}
+
+module "gke_autopilot" {
+  source = "./modules/gke_autopilot"
+
+  project_id       = var.project_id
+  region           = var.region
+  cluster_name     = var.cluster_name
+  cluster_labels   = var.cluster_labels
+  enable_autopilot = var.enable_autopilot
+}
+
+
+module "gke_standard" {
+  source = "./modules/gke_standard"
+
+  project_id                = var.project_id
+  region                    = var.region
+  cluster_name              = var.cluster_name
+  cluster_labels            = var.cluster_labels
+  enable_autopilot          = var.enable_autopilot
+  enable_tpu                = var.enable_tpu
+  gpu_pool_machine_type     = var.gpu_pool_machine_type
+  gpu_pool_accelerator_type = var.gpu_pool_accelerator_type
+  gpu_pool_node_locations   = var.gpu_pool_node_locations
+}
+
+module "kubernetes" {
+  source = "./modules/kubernetes"
+
+  depends_on       = [module.gke_standard]
+  region           = var.region
+  cluster_name     = var.cluster_name
+  enable_autopilot = var.enable_autopilot
+  enable_tpu       = var.enable_tpu
+}
+
+module "kuberay" {
+  source = "./modules/kuberay"
+
+  depends_on       = [module.gke_autopilot, module.gke_standard]
+  region           = var.region
+  cluster_name     = var.cluster_name
+  enable_autopilot = var.enable_autopilot
+}

--- a/ai-ml/gke-ray/gke-platform/modules/gke_autopilot/main.tf
+++ b/ai-ml/gke-ray/gke-platform/modules/gke_autopilot/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/gke-platform/modules/gke_autopilot/main.tf
+++ b/ai-ml/gke-ray/gke-platform/modules/gke_autopilot/main.tf
@@ -1,0 +1,54 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+
+# GKE cluster
+resource "google_container_cluster" "ml_cluster" {
+  name     = var.cluster_name
+  location = var.region
+  count    = var.enable_autopilot == true ? 1 : 0
+
+  initial_node_count = 1
+
+  logging_config {
+    enable_components = ["SYSTEM_COMPONENTS", "WORKLOADS"]
+  }
+
+  monitoring_config {
+    enable_components = ["SYSTEM_COMPONENTS"]
+    managed_prometheus {
+      enabled = "true"
+    }
+  }
+  ip_allocation_policy {
+    cluster_ipv4_cidr_block  = ""
+    services_ipv4_cidr_block = ""
+  }
+
+  enable_autopilot = true
+
+  release_channel {
+    channel = "RAPID"
+  }
+
+  min_master_version = "1.28"
+
+  resource_labels = var.cluster_labels
+}
+

--- a/ai-ml/gke-ray/gke-platform/modules/gke_autopilot/output.tf
+++ b/ai-ml/gke-ray/gke-platform/modules/gke_autopilot/output.tf
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/gke-platform/modules/gke_autopilot/output.tf
+++ b/ai-ml/gke-ray/gke-platform/modules/gke_autopilot/output.tf
@@ -1,0 +1,38 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "project_id" {
+  description = "GCP project id"
+  value       = var.enable_autopilot ? resource.google_container_cluster.ml_cluster[0].project : null
+}
+
+output "region" {
+  description = "GCP region"
+  value       = var.enable_autopilot ? resource.google_container_cluster.ml_cluster[0].location : null
+}
+
+output "cluster_name" {
+  description = "The name of the GKE cluster"
+  value       = var.enable_autopilot ? resource.google_container_cluster.ml_cluster[0].name : null
+}
+
+output "kubernetes_host" {
+  description = "Kubernetes cluster host"
+  value       = var.enable_autopilot ? resource.google_container_cluster.ml_cluster[0].endpoint : null
+}
+
+output "cluster_certificate" {
+  description = "Kubernetes cluster CA certificate"
+  value       = var.enable_autopilot ? base64decode(resource.google_container_cluster.ml_cluster[0].master_auth[0].cluster_ca_certificate) : null
+}

--- a/ai-ml/gke-ray/gke-platform/modules/gke_autopilot/variables.tf
+++ b/ai-ml/gke-ray/gke-platform/modules/gke_autopilot/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/gke-platform/modules/gke_autopilot/variables.tf
+++ b/ai-ml/gke-ray/gke-platform/modules/gke_autopilot/variables.tf
@@ -1,0 +1,56 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project_id" {
+  type        = string
+  description = "GCP project id"
+  default     = "ricliu-gke-dev"
+}
+
+variable "region" {
+  type        = string
+  description = "GCP project region or zone"
+  default     = "us-central1"
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "GKE cluster name"
+  default     = "ml-cluster"
+}
+
+variable "cluster_labels" {
+  type        = map
+  description = "GKE cluster labels"
+  default     =  {
+    created-by = "ai-on-gke"
+  }
+}
+
+variable "namespace" {
+  type        = string
+  description = "Kubernetes namespace where resources are deployed"
+  default     = "ray"
+}
+
+variable "num_gpu_nodes" {
+  description = "Number of GPU nodes in the cluster"
+  default     = 1
+}
+
+variable "enable_autopilot" {
+  type        = bool
+  description = "Set to true to enable GKE Autopilot clusters"
+  default     = false
+}

--- a/ai-ml/gke-ray/gke-platform/modules/gke_autopilot/versions.tf
+++ b/ai-ml/gke-ray/gke-platform/modules/gke_autopilot/versions.tf
@@ -1,0 +1,21 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+  }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-kubernetes-engine:kuberay/v0.1.0"
+  }
+}

--- a/ai-ml/gke-ray/gke-platform/modules/gke_autopilot/versions.tf
+++ b/ai-ml/gke-ray/gke-platform/modules/gke_autopilot/versions.tf
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/gke-platform/modules/gke_standard/main.tf
+++ b/ai-ml/gke-ray/gke-platform/modules/gke_standard/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/gke-platform/modules/gke_standard/main.tf
+++ b/ai-ml/gke-ray/gke-platform/modules/gke_standard/main.tf
@@ -1,0 +1,166 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+}
+
+# GKE cluster
+resource "google_container_cluster" "ml_cluster" {
+  name                     = var.cluster_name
+  location                 = var.region
+  count                    = var.enable_autopilot == false ? 1 : 0
+  remove_default_node_pool = true
+  initial_node_count       = 1
+  min_master_version       = "1.28"
+
+  logging_config {
+    enable_components = ["SYSTEM_COMPONENTS", "WORKLOADS"]
+  }
+
+  monitoring_config {
+    enable_components = ["SYSTEM_COMPONENTS"]
+    managed_prometheus {
+      enabled = "true"
+    }
+  }
+
+  workload_identity_config {
+    workload_pool = "${var.project_id}.svc.id.goog"
+  }
+
+  addons_config {
+    gcs_fuse_csi_driver_config {
+      enabled = true
+    }
+  }
+
+  release_channel {
+    channel = "RAPID"
+  }
+
+  resource_labels = var.cluster_labels
+}
+
+resource "google_container_node_pool" "cpu_pool" {
+  name     = "cpu-pool"
+  location = var.region
+  count    = var.enable_autopilot ? 0 : 1
+  cluster  = var.enable_autopilot ? null : google_container_cluster.ml_cluster[0].name
+
+  autoscaling {
+    min_node_count = 1
+    max_node_count = 3
+  }
+
+  management {
+    auto_repair  = "true"
+    auto_upgrade = "true"
+  }
+
+  node_config {
+    machine_type = "n1-standard-16"
+  }
+}
+
+resource "google_container_node_pool" "gpu_pool" {
+  name       = "gpu-pool"
+  location   = var.region
+  node_count = var.num_nodes
+  count      = var.enable_autopilot || var.enable_tpu ? 0 : 1
+  cluster    = var.enable_autopilot || var.enable_tpu ? null : google_container_cluster.ml_cluster[0].name
+
+  node_locations = var.gpu_pool_node_locations
+  
+  autoscaling {
+    min_node_count = "1"
+    max_node_count = "3"
+  }
+
+  management {
+    auto_repair  = "true"
+    auto_upgrade = "true"
+  }
+
+  node_config {
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/trace.append",
+      "https://www.googleapis.com/auth/service.management.readonly",
+      "https://www.googleapis.com/auth/servicecontrol",
+    ]
+
+    labels = {
+      "cloud.google.com/gke-profile" = "ray"
+      env                            = var.project_id
+    }
+
+    guest_accelerator {
+      type  = var.gpu_pool_accelerator_type
+      count = 2
+    }
+
+    # preemptible  = true
+    image_type   = "cos_containerd"
+    machine_type = var.gpu_pool_machine_type
+    tags         = ["gke-node", "${var.project_id}-gke"]
+
+    disk_size_gb = "200"
+    disk_type    = "pd-balanced"
+
+    metadata = {
+      disable-legacy-endpoints = "true"
+    }
+  }
+}
+
+resource "google_container_node_pool" "tpu_pool" {
+  provider           = google-beta
+  name               = "tpu-pool"
+  location           = var.region
+  node_locations     = ["us-central2-b"]
+  cluster            = var.enable_autopilot == false && var.enable_tpu ? google_container_cluster.ml_cluster[0].name : null
+  initial_node_count = var.num_nodes
+  count              = var.enable_autopilot == false && var.enable_tpu ? 1 : 0
+
+  node_config {
+    machine_type = "ct4p-hightpu-4t"
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/trace.append",
+      "https://www.googleapis.com/auth/service.management.readonly",
+      "https://www.googleapis.com/auth/servicecontrol",
+    ]
+
+    labels = {
+      "cloud.google.com/gke-profile" = "ray"
+      env                            = var.project_id
+    }
+  }
+
+  placement_policy {
+    tpu_topology = "2x2x1"
+    type         = "COMPACT"
+  }
+}

--- a/ai-ml/gke-ray/gke-platform/modules/gke_standard/output.tf
+++ b/ai-ml/gke-ray/gke-platform/modules/gke_standard/output.tf
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/gke-platform/modules/gke_standard/output.tf
+++ b/ai-ml/gke-ray/gke-platform/modules/gke_standard/output.tf
@@ -1,0 +1,38 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "project_id" {
+  description = "GCP project id"
+  value       = var.enable_autopilot ? null : resource.google_container_cluster.ml_cluster[0].project
+}
+
+output "region" {
+  description = "GCP region"
+  value       = var.enable_autopilot ? null : resource.google_container_cluster.ml_cluster[0].location
+}
+
+output "cluster_name" {
+  description = "The name of the GKE cluster"
+  value       = var.enable_autopilot ? null : resource.google_container_cluster.ml_cluster[0].name
+}
+
+output "kubernetes_host" {
+  description = "Kubernetes cluster host"
+  value       = var.enable_autopilot ? null : resource.google_container_cluster.ml_cluster[0].endpoint
+}
+
+output "cluster_certificate" {
+  description = "Kubernetes cluster CA certificate"
+  value       = var.enable_autopilot ? null : base64decode(resource.google_container_cluster.ml_cluster[0].master_auth[0].cluster_ca_certificate)
+}

--- a/ai-ml/gke-ray/gke-platform/modules/gke_standard/variables.tf
+++ b/ai-ml/gke-ray/gke-platform/modules/gke_standard/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/gke-platform/modules/gke_standard/variables.tf
+++ b/ai-ml/gke-ray/gke-platform/modules/gke_standard/variables.tf
@@ -1,0 +1,80 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project_id" {
+  type        = string
+  description = "GCP project id"
+  default     = "ricliu-gke-dev"
+}
+
+variable "region" {
+  type        = string
+  description = "GCP project region or zone"
+  default     = "us-central1"
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "GKE cluster name"
+  default     = "ml-cluster"
+}
+
+variable "cluster_labels" {
+  type        = map
+  description = "GKE cluster labels"
+  default     =  {
+    created-by = "ai-on-gke"
+  }
+}
+
+variable "namespace" {
+  type        = string
+  description = "Kubernetes namespace where resources are deployed"
+  default     = "ray"
+}
+
+variable "num_nodes" {
+  description = "Number of GPU / TPU nodes in the cluster"
+  default     = 1
+}
+
+variable "enable_autopilot" {
+  type        = bool
+  description = "Set to true to enable GKE Autopilot clusters"
+  default     = false
+}
+
+variable "enable_tpu" {
+  type        = bool
+  description = "Set to true to create TPU node pool"
+  default     = false
+}
+
+variable "gpu_pool_machine_type" {
+  type        = string
+  description = "Specify the gpu-pool machine type"
+  default     = "n1-standard-16"
+}
+
+variable "gpu_pool_accelerator_type" {
+  type        = string
+  description = "Specify the gpu-pool machine type"
+  default     = "nvidia-tesla-t4"
+}
+
+variable "gpu_pool_node_locations" {
+  type        = list
+  description = "Specify the gpu-pool node zone locations"
+  default     = ["us-central1-a", "us-central1-c", "us-central1-f"]
+}

--- a/ai-ml/gke-ray/gke-platform/modules/gke_standard/versions.tf
+++ b/ai-ml/gke-ray/gke-platform/modules/gke_standard/versions.tf
@@ -1,0 +1,21 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+  }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-kubernetes-engine:kuberay/v0.1.0"
+  }
+}

--- a/ai-ml/gke-ray/gke-platform/modules/gke_standard/versions.tf
+++ b/ai-ml/gke-ray/gke-platform/modules/gke_standard/versions.tf
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/gke-platform/modules/kuberay/kuberay-operator-autopilot-values.yaml
+++ b/ai-ml/gke-ray/gke-platform/modules/kuberay/kuberay-operator-autopilot-values.yaml
@@ -1,0 +1,117 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Default values for kuberay-operator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: kuberay/operator
+  tag: v1.0.0
+  pullPolicy: IfNotPresent
+
+nameOverride: "kuberay-operator"
+fullnameOverride: "kuberay-operator"
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: "kuberay-operator"
+
+service:
+  type: ClusterIP
+  port: 8080
+
+resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do whelm to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  limits:
+    cpu: 100m
+    # Anecdotally, managing 500 Ray pods requires roughly 500MB memory.
+    # Monitor memory usage and adjust as needed.
+    memory: 512Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 512Mi
+
+livenessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  failureThreshold: 5
+
+readinessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  failureThreshold: 5
+
+batchScheduler:
+  enabled: false
+
+# Set up `securityContext` to improve Pod security.
+# See https://github.com/ray-project/kuberay/blob/master/docs/guidance/pod-security.md for further guidance.
+securityContext: {}
+
+
+# If rbacEnable is set to false, no RBAC resources will be created, including the Role for leader election, the Role for Pods and Services, and so on.
+rbacEnable: true
+
+# When crNamespacedRbacEnable is set to true, the KubeRay operator will create a Role for RayCluster preparation (e.g., Pods, Services)
+# and a corresponding RoleBinding for each namespace listed in the "watchNamespace" parameter. Please note that even if crNamespacedRbacEnable
+# is set to false, the Role and RoleBinding for leader election will still be created.
+#
+# Note:
+# (1) This variable is only effective when rbacEnable and singleNamespaceInstall are both set to true.
+# (2) In most cases, it should be set to true, unless you are using a Kubernetes cluster managed by GitOps tools such as ArgoCD.
+crNamespacedRbacEnable: true
+
+# When singleNamespaceInstall is true:
+# - Install namespaced RBAC resources such as Role and RoleBinding instead of cluster-scoped ones like ClusterRole and ClusterRoleBinding so that
+#   the chart can be installed by users with permissions restricted to a single namespace.
+#   (Please note that this excludes the CRDs, which can only be installed at the cluster scope.)
+# - If "watchNamespace" is not set, the KubeRay operator will, by default, only listen
+#   to resource events within its own namespace.
+singleNamespaceInstall: false
+
+# The KubeRay operator will watch the custom resources in the namespaces listed in the "watchNamespace" parameter.
+# watchNamespace:
+#   - n1
+#   - n2
+
+# Environment variables
+env:
+# If not set or set to true, kuberay auto injects an init container waiting for ray GCS.
+# If false, you will need to inject your own init container to ensure ray GCS is up before the ray workers start.
+# Warning: we highly recommend setting to true and let kuberay handle for you.
+- name: ENABLE_INIT_CONTAINER_INJECTION
+  value: "false"
+# If not set or set to "", kuberay will pick up the default k8s cluster domain `cluster.local`
+# Otherwise, kuberay will use your custom domain
+# - name: CLUSTER_DOMAIN
+#   value: ""
+# If not set or set to false, when running on OpenShift with Ingress creation enabled, kuberay will create OpenShift route
+# Otherwise, regardless of the type of cluster with Ingress creation enabled, kuberay will create Ingress
+# - name: USE_INGRESS_ON_OPENSHIFT
+#   value: "true"
+# Unconditionally requeue after the number of seconds specified in the
+# environment variable RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV. If the
+# environment variable is not set, requeue after the default value (300).
+# - name: RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV
+#   value: 300
+# If not set or set to "true", KubeRay will clean up the Redis storage namespace when a GCS FT-enabled RayCluster is deleted.
+# - name: ENABLE_GCS_FT_REDIS_CLEANUP
+#   value: "true"

--- a/ai-ml/gke-ray/gke-platform/modules/kuberay/kuberay-operator-autopilot-values.yaml
+++ b/ai-ml/gke-ray/gke-platform/modules/kuberay/kuberay-operator-autopilot-values.yaml
@@ -1,4 +1,4 @@
-#  Copyright 2023 Google LLC
+#  Copyright 2024 Google LLC
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/gke-platform/modules/kuberay/kuberay-operator-values.yaml
+++ b/ai-ml/gke-ray/gke-platform/modules/kuberay/kuberay-operator-values.yaml
@@ -1,0 +1,117 @@
+#  Copyright 2023 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# Default values for kuberay-operator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: kuberay/operator
+  tag: v1.0.0
+  pullPolicy: IfNotPresent
+
+nameOverride: "kuberay-operator"
+fullnameOverride: "kuberay-operator"
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: "kuberay-operator"
+
+service:
+  type: ClusterIP
+  port: 8080
+
+resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do whelm to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  limits:
+    cpu: 100m
+    # Anecdotally, managing 500 Ray pods requires roughly 500MB memory.
+    # Monitor memory usage and adjust as needed.
+    memory: 512Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 512Mi
+
+livenessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  failureThreshold: 5
+
+readinessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  failureThreshold: 5
+
+batchScheduler:
+  enabled: false
+
+# Set up `securityContext` to improve Pod security.
+# See https://github.com/ray-project/kuberay/blob/master/docs/guidance/pod-security.md for further guidance.
+securityContext: {}
+
+
+# If rbacEnable is set to false, no RBAC resources will be created, including the Role for leader election, the Role for Pods and Services, and so on.
+rbacEnable: true
+
+# When crNamespacedRbacEnable is set to true, the KubeRay operator will create a Role for RayCluster preparation (e.g., Pods, Services)
+# and a corresponding RoleBinding for each namespace listed in the "watchNamespace" parameter. Please note that even if crNamespacedRbacEnable
+# is set to false, the Role and RoleBinding for leader election will still be created.
+#
+# Note:
+# (1) This variable is only effective when rbacEnable and singleNamespaceInstall are both set to true.
+# (2) In most cases, it should be set to true, unless you are using a Kubernetes cluster managed by GitOps tools such as ArgoCD.
+crNamespacedRbacEnable: true
+
+# When singleNamespaceInstall is true:
+# - Install namespaced RBAC resources such as Role and RoleBinding instead of cluster-scoped ones like ClusterRole and ClusterRoleBinding so that
+#   the chart can be installed by users with permissions restricted to a single namespace.
+#   (Please note that this excludes the CRDs, which can only be installed at the cluster scope.)
+# - If "watchNamespace" is not set, the KubeRay operator will, by default, only listen
+#   to resource events within its own namespace.
+singleNamespaceInstall: false
+
+# The KubeRay operator will watch the custom resources in the namespaces listed in the "watchNamespace" parameter.
+# watchNamespace:
+#   - n1
+#   - n2
+
+# Environment variables
+env:
+# If not set or set to true, kuberay auto injects an init container waiting for ray GCS.
+# If false, you will need to inject your own init container to ensure ray GCS is up before the ray workers start.
+# Warning: we highly recommend setting to true and let kuberay handle for you.
+# - name: ENABLE_INIT_CONTAINER_INJECTION
+#   value: "true"
+# If not set or set to "", kuberay will pick up the default k8s cluster domain `cluster.local`
+# Otherwise, kuberay will use your custom domain
+# - name: CLUSTER_DOMAIN
+#   value: ""
+# If not set or set to false, when running on OpenShift with Ingress creation enabled, kuberay will create OpenShift route
+# Otherwise, regardless of the type of cluster with Ingress creation enabled, kuberay will create Ingress
+# - name: USE_INGRESS_ON_OPENSHIFT
+#   value: "true"
+# Unconditionally requeue after the number of seconds specified in the
+# environment variable RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV. If the
+# environment variable is not set, requeue after the default value (300).
+# - name: RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV
+#   value: 300
+# If not set or set to "true", KubeRay will clean up the Redis storage namespace when a GCS FT-enabled RayCluster is deleted.
+# - name: ENABLE_GCS_FT_REDIS_CLEANUP
+#   value: "true"

--- a/ai-ml/gke-ray/gke-platform/modules/kuberay/kuberay-operator-values.yaml
+++ b/ai-ml/gke-ray/gke-platform/modules/kuberay/kuberay-operator-values.yaml
@@ -1,4 +1,4 @@
-#  Copyright 2023 Google LLC
+#  Copyright 2024 Google LLC
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/gke-platform/modules/kuberay/kuberay.tf
+++ b/ai-ml/gke-ray/gke-platform/modules/kuberay/kuberay.tf
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/gke-platform/modules/kuberay/kuberay.tf
+++ b/ai-ml/gke-ray/gke-platform/modules/kuberay/kuberay.tf
@@ -1,0 +1,28 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "kubernetes_namespace" "ray_namespace" {
+  metadata {
+    name = var.namespace
+  }
+}
+
+resource "helm_release" "kuberay-operator" {
+  name       = "kuberay-operator"
+  repository = "https://ray-project.github.io/kuberay-helm/"
+  chart      = "kuberay-operator"
+  values     = var.enable_autopilot ? [file("${path.module}/kuberay-operator-autopilot-values.yaml")] : [file("${path.module}/kuberay-operator-values.yaml")]
+  version    = "1.0.0"
+  namespace  = "${kubernetes_namespace.ray_namespace.metadata[0].name}"
+}

--- a/ai-ml/gke-ray/gke-platform/modules/kuberay/variables.tf
+++ b/ai-ml/gke-ray/gke-platform/modules/kuberay/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/gke-platform/modules/kuberay/variables.tf
+++ b/ai-ml/gke-ray/gke-platform/modules/kuberay/variables.tf
@@ -1,0 +1,37 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "region" {
+  type        = string
+  description = "GCP project region or zone"
+  default     = "us-central1"
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "Kubernetes cluster name"
+  default     = "ml-cluster"
+}
+
+variable "namespace" {
+  type        = string
+  description = "Kubernetes namespace where resources are deployed"
+  default     = "ray-system"
+}
+
+variable "enable_autopilot" {
+  type        = bool
+  description = "Set to true to enable GKE Autopilot clusters"
+  default     = false
+}

--- a/ai-ml/gke-ray/gke-platform/modules/kuberay/versions.tf
+++ b/ai-ml/gke-ray/gke-platform/modules/kuberay/versions.tf
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/gke-platform/modules/kuberay/versions.tf
+++ b/ai-ml/gke-ray/gke-platform/modules/kuberay/versions.tf
@@ -1,0 +1,29 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.8.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "2.18.1"
+    }
+  }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-kubernetes-engine:kuberay/v0.1.0"
+  }
+}

--- a/ai-ml/gke-ray/gke-platform/modules/kubernetes/kubernetes.tf
+++ b/ai-ml/gke-ray/gke-platform/modules/kubernetes/kubernetes.tf
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/gke-platform/modules/kubernetes/kubernetes.tf
+++ b/ai-ml/gke-ray/gke-platform/modules/kubernetes/kubernetes.tf
@@ -1,0 +1,22 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data "http" "nvidia_driver_installer_manifest" {
+  url = "https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/cos/daemonset-preloaded.yaml"
+}
+
+resource "kubectl_manifest" "nvidia_driver_installer" {
+  yaml_body = data.http.nvidia_driver_installer_manifest.response_body
+  count = var.enable_tpu || var.enable_autopilot ? 0 : 1
+}

--- a/ai-ml/gke-ray/gke-platform/modules/kubernetes/variables.tf
+++ b/ai-ml/gke-ray/gke-platform/modules/kubernetes/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/gke-platform/modules/kubernetes/variables.tf
+++ b/ai-ml/gke-ray/gke-platform/modules/kubernetes/variables.tf
@@ -1,0 +1,43 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "region" {
+  type        = string
+  description = "GCP project region or zone"
+  default     = "us-central1"
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "Kubernetes cluster name"
+  default     = "ml-cluster"
+}
+
+variable "namespace" {
+  type        = string
+  description = "Kubernetes namespace where resources are deployed"
+  default     = "ray"
+}
+
+variable "enable_autopilot" {
+  type        = bool
+  description = "Set to true to enable GKE Autopilot clusters"
+  default     = false
+}
+
+variable "enable_tpu" {
+  type = bool
+  description = "Set to true to create TPU node pool, only one accelerator pool (GPU or TPU) will be created"
+  default = false
+}

--- a/ai-ml/gke-ray/gke-platform/modules/kubernetes/versions.tf
+++ b/ai-ml/gke-ray/gke-platform/modules/kubernetes/versions.tf
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/gke-platform/modules/kubernetes/versions.tf
+++ b/ai-ml/gke-ray/gke-platform/modules/kubernetes/versions.tf
@@ -1,0 +1,33 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.8.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "2.18.1"
+    }
+    kubectl = {
+      source  = "alekc/kubectl"
+      version = "2.0.1"
+    }
+  }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-kubernetes-engine:kuberay/v0.1.0"
+  }
+}

--- a/ai-ml/gke-ray/gke-platform/variables.tf
+++ b/ai-ml/gke-ray/gke-platform/variables.tf
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/gke-platform/variables.tf
+++ b/ai-ml/gke-ray/gke-platform/variables.tf
@@ -1,0 +1,69 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project_id" {
+  type        = string
+  description = "GCP project id"
+  default     = "<your project>"
+}
+
+variable "region" {
+  type        = string
+  description = "GCP project region or zone"
+  default     = "us-central1"
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "GKE cluster name"
+  default     = "ml-cluster"
+}
+
+variable "cluster_labels" {
+  type        = map
+  description = "GKE cluster labels"
+  default     =  {
+    created-by = "ai-on-gke"
+  }
+}
+
+variable "enable_autopilot" {
+  type        = bool
+  description = "Set to true to enable GKE Autopilot clusters"
+  default     = false
+}
+
+variable "enable_tpu" {
+  type        = bool
+  description = "Set to true to create TPU node pool"
+  default     = false
+}
+
+variable "gpu_pool_machine_type" {
+  type        = string
+  description = "Specify the gpu-pool machine type"
+  default     = "n1-standard-16"
+}
+
+variable "gpu_pool_accelerator_type" {
+  type        = string
+  description = "Specify the gpu accelerator type"
+  default     = "nvidia-tesla-t4"
+}
+
+variable "gpu_pool_node_locations" {
+  type        = list
+  description = "Specify the gpu-pool node zone locations"
+  default     = ["us-central1-a", "us-central1-c", "us-central1-f"]
+}

--- a/ai-ml/gke-ray/gke-platform/versions.tf
+++ b/ai-ml/gke-ray/gke-platform/versions.tf
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/gke-platform/versions.tf
+++ b/ai-ml/gke-ray/gke-platform/versions.tf
@@ -1,0 +1,40 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    google = {
+      source = "hashicorp/google"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 4.8"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.8.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "2.18.1"
+    }
+    kubectl = {
+      source  = "alekc/kubectl"
+      version = "2.0.1"
+    }
+  }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-kubernetes-engine:kuberay/v0.1.0"
+  }
+}

--- a/ai-ml/gke-ray/rayserve/README.md
+++ b/ai-ml/gke-ray/rayserve/README.md
@@ -1,0 +1,297 @@
+# Serve meta llama2 7b, llama2 70b quantized, falcon 7b-instruct or falcon 40b-instruct quantized models
+
+Use `RayService` and `ray-llm`, which manages a Ray Cluster to load your models for inferencing 
+
+## Get a huggingface token and apply for access to the llama2 model
+- Sign up for huggingface account
+- Get your read API token
+  - Profile -> Settings -> Access Token -> New Token
+- Enable access to the [model](https://huggingface.co/meta-llama/Llama-2-7b-chat-hf) on huggingface
+
+## Pre-requisites
+- Navigate to the `gke-platform` folder
+- Specify values to deploy `L4` GPUs in the cluster, in the `gke-platform` folder.
+    - Autopilot
+    ```zsh
+    cat << EOF > terraform.tfvars
+    enable_autopilot=true
+    EOF
+    ```
+
+    - Standard
+    ```zsh
+    cat << EOF > terraform.tfvars
+    gpu_pool_machine_type="g2-standard-24"
+    gpu_pool_accelerator_type="nvidia-l4"
+    gpu_pool_node_locations=["us-central1-a", "us-central1-c"]
+    EOF
+    ```
+
+- Deploy GKE
+```zsh
+terraform init
+terraform apply --auto-approve
+```
+ 
+- Return to the `ray-on-gke/rayservice-examples` folder
+- Prepare your HF token as a secret
+> NOTE: In this example, this is needed for the llama-2 models, not the falcon.
+```zsh
+export HF_API_TOKEN=<<YOUR_HF_API_TOKEN>>
+kubectl create secret generic hf-secret \
+    --from-literal=hf_api_token=${HF_API_TOKEN} \
+    --dry-run=client -o yaml > hf-secret.yaml
+```
+
+- Get context to your GKE cluster
+```zsh
+gcloud container clusters get-credentials ml-cluster --region us-central1
+```
+
+> NOTE: The pre-built rayllm container image has models that references different accelerator types. For this example we are using nvidia `L4` GPUs, so the `spec.serveConfigV2` in `RayService` points to a [repo archive](https://github.com/kenthua/ai-ml) which contains models that uses the `L4` accelerator type. Alternatively, you can build an image as part of the pipeline and include your desired models.
+
+## Instructions for meta llama2 7b or falcon 7b-instruct chat model
+This example uses the `rayllm.backend:router_application` to load the model.
+
+- Deploy the RayService, below is the llama2 7b model, but you can change the `rayservice-*` filename to your desired model. llama2 7b or falcon 7b 
+    - Autopilot
+    ```zsh
+    kubectl apply -f hf-secret.yaml
+    kubectl apply -f ap_pvc-rayservice.yaml
+    kubectl apply -f models/llama2-7b-chat-hf.yaml
+    kubectl apply -f ap_llama2-7b.yaml
+    ```
+
+    - Standard
+    ```zsh
+    kubectl apply -f hf-secret.yaml
+    kubectl apply -f models/llama2-7b-chat-hf.yaml
+    kubectl apply -f llama2-7b.yaml
+    ```
+
+- Confirm the model is ready, from status `DEPLOYING` to `RUNNING`
+```zsh
+export HEAD_POD=$(kubectl get pods --selector=ray.io/node-type=head -n default -o custom-columns=POD:metadata.name --no-headers)
+
+watch --color --interval 5 --no-title "kubectl exec -n default -it $HEAD_POD -- serve status | GREP_COLOR='01;92' egrep --color=always -e '^' -e 'RUNNING'"
+```
+
+### Access the serving endpoint
+- Port forward the serving port to your local environment
+```
+kubectl port-forward service/rayllm-serve-svc 8000:8000
+```
+
+- Test out the inference endpoint
+> NOTE: Change the model below in the json model value to reflect the deployed model. i.e. `tiiuae/falcon-7b`.
+
+```zsh
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "meta-llama/Llama-2-7b-chat-hf",
+    "messages": [
+      {"role": "system", "content": "You are a helpful assistant."},
+      {"role": "user", "content": "What are the top 5 most popular programming languages? Please be brief."}
+    ],
+    "temperature": 0.7
+  }'
+```
+
+### Test out the endpoint with a sample gradio app
+
+The [sample gradio app](https://github.com/kenthua/gradio-app) at the moment only supports chat completions json spec so it won't work with TGI text spec, which is what the quantized models in the later section uses. If you deploy the gradio application, you do not need the port forward of 8000 above
+
+- Deploy the sample gradio application
+> NOTE: If you deploy other models such as the `falcon-7b`, be sure to change the model value in the `gradio.yaml`.
+
+```zsh
+kubectl apply -f gradio.yaml
+```
+
+- Extract out the external IP of the service to be used. It may take a few minutes for the IP to be available.
+```zsh
+EXTERNAL_IP=$(kubectl get services gradio \
+    --output jsonpath='{.status.loadBalancer.ingress[0].ip}')
+echo -e "\nGradio URL: http://${EXTERNAL_IP}\n"
+```
+
+## Instructions for meta llama-2 70b chat or falcon 40b-instruct model with 4bit quantization
+
+> NOTE: If you deployed the previous 7b example, it will be overwritten by this example. You will also need the huggingface api token for the falcon 40b-instruct example because it's an input for the huggingface transformer example.
+
+The `spec.serveConfigV2.applications.import_path` points to custom python which uses huggingface transformer `BitsAndBytesConfig` & `AutoModelForCausalLM` libraries to load the quantized model, so that we can fit the 70b or 40b parameter models into 2x `L4` GPUs. This example uses `ray-llm` as the container image though it's not using the `rayllm.backend:router_application` to load the model.
+
+- Deploy the RayService, below is the llama2 70b model, but you can change the `rayservice-*` filename to your desired model. llama2 70b or falcon 40b.
+    - Autopilot
+    ```zsh
+    kubectl apply -f hf-secret.yaml
+    kubectl apply -f ap_pvc-rayservice.yaml
+    kubectl apply -f models/quantized-model.yaml
+    kubectl apply -f ap_llama2-70b.yaml
+    ```
+
+    - Standard
+    ```zsh
+    kubectl apply -f hf-secret.yaml
+    kubectl apply -f models/quantized-model.yaml
+    kubectl apply -f llama2-70b.yaml
+    ```
+
+- Confirm the model is ready, from status `DEPLOYING` to `RUNNING`
+```zsh
+export HEAD_POD=$(kubectl get pods --selector=ray.io/node-type=head -n default -o custom-columns=POD:metadata.name --no-headers)
+
+watch --color --interval 5 --no-title "kubectl exec -n default -it $HEAD_POD -- serve status | GREP_COLOR='01;92' egrep --color=always -e '^' -e 'RUNNING'"
+```
+
+### Access the serving endpoint
+- Port forward the serving port to your local environment
+```
+kubectl port-forward service/rayllm-serve-svc 8000:8000
+```
+
+- Test out the inference endpoint
+```zsh
+curl -X POST http://localhost:8000/ \
+  -H "Content-Type: application/json" \
+  -d '{"text": "What are the top 5 most popular programming languages? Please be brief."}'
+```
+
+## Insights & Debugging
+
+Debugging and insights can be made available through Ray either via CLI or UI
+
+### UI
+
+Through the UI, the ray head group provides a layer to view the status of the Ray cluster. It provides observability of your Ray Cluster such as: status, resource consumption, jobs, etc
+
+- Forward the head port 8265 to access the UI
+```zsh
+export HEAD_POD=$(kubectl get pods --selector=ray.io/node-type=head -n default -o custom-columns=POD:metadata.name --no-headers)
+
+kubectl port-forward pod/$HEAD_POD 8265:8265
+```
+
+### CLI
+
+Ray provides both `ray` and `serve` CLI tools to view status of your Ray Cluster
+
+- Exec into the Ray head pod to be able to run the CLI commands
+```zsh
+export HEAD_POD=$(kubectl get pods --selector=ray.io/node-type=head -n default -o custom-columns=POD:metadata.name --no-headers)
+
+kubectl exec -n default -it $HEAD_POD -- bash
+```
+
+Once in the shell of the head pod you can run a few commands
+
+- The status of this Ray cluster
+```zsh
+ray status
+```
+
+Output (do not copy)
+```zsh
+======== Autoscaler status: 2023-11-13 14:16:18.210554 ========
+Node status
+---------------------------------------------------------------
+Healthy:
+ 1 node_dc3f939f1b0ed1b731eefe1857bdb2d86fca5a33555a1c32389c4d46
+ 1 node_9bae5b87f4cee179dabd482d3e13d5df9eb67e728c62d709925688b7
+Pending:
+ (no pending nodes)
+Recent failures:
+ (no failures)
+
+Resources
+---------------------------------------------------------------
+Usage:
+ 3.0/22.0 CPU (1.0 used of 4.0 reserved in placement groups)
+ 1.0/3.0 GPU (1.0 used of 1.0 reserved in placement groups)
+ 0.0/22.0 accelerator_type_cpu
+ 0.010000000000000018/1.0 accelerator_type_l4 (0.01 used of 0.02 reserved in placement groups)
+ 0B/26.63GiB memory
+ 88B/7.87GiB object_store_memory
+
+Demands:
+ (no resource demands)
+```
+
+- The nodes for this Ray cluster
+```zsh
+ray list nodes
+```
+
+Output (do not copy)
+```zsh
+======== List: 2023-11-13 14:16:39.406959 ========
+Stats:
+------------------------------
+Total: 2
+
+Table:
+------------------------------
+    NODE_ID                                                   NODE_IP     IS_HEAD_NODE    STATE    NODE_NAME    RESOURCES_TOTAL                 LABELS
+ 0  9bae5b87f4cee179dabd482d3e13d5df9eb67e728c62d709925688b7  10.92.0.10  True            ALIVE    10.92.0.10   CPU: 2.0                        ray.io/node_id: 9bae5b87f4cee179dabd482d3e13d5df9eb67e728c62d709925688b7
+                                                                                                                GPU: 2.0
+                                                                                                                accelerator_type:L4: 1.0
+                                                                                                                accelerator_type_cpu: 2.0
+                                                                                                                memory: 8.000 GiB
+                                                                                                                node:10.92.0.10: 1.0
+                                                                                                                node:__internal_head__: 1.0
+                                                                                                                object_store_memory: 2.307 GiB
+ 1  dc3f939f1b0ed1b731eefe1857bdb2d86fca5a33555a1c32389c4d46  10.92.0.11  False           ALIVE    10.92.0.11   CPU: 20.0                       ray.io/node_id: dc3f939f1b0ed1b731eefe1857bdb2d86fca5a33555a1c32389c4d46
+                                                                                                                GPU: 1.0
+                                                                                                                accelerator_type:L4: 1.0
+                                                                                                                accelerator_type_cpu: 20.0
+                                                                                                                accelerator_type_l4: 1.0
+                                                                                                                memory: 18.626 GiB
+                                                                                                                node:10.92.0.11: 1.0
+                                                                                                                object_store_memory: 5.561 GiB
+```
+
+- The config that Ray serve has loaded
+```zsh
+serve config
+```
+
+Output (do not copy)
+```zsh
+name: ray-llm
+route_prefix: /
+import_path: rayllm.backend:router_application
+runtime_env:
+  working_dir: https://github.com/kenthua/ai-ml/archive/refs/tags/v0.0.5.zip
+args:
+  models:
+  - ./models/meta-llama--Llama-2-7b-chat-hf.yaml
+```
+
+- The status of what Ray is serving
+```zsh
+serve status
+```
+
+Output (do not copy)
+```zsh
+proxies:
+  9bae5b87f4cee179dabd482d3e13d5df9eb67e728c62d709925688b7: HEALTHY
+  dc3f939f1b0ed1b731eefe1857bdb2d86fca5a33555a1c32389c4d46: HEALTHY
+applications:
+  ray-llm:
+    status: RUNNING
+    message: ''
+    last_deployed_time_s: 1699909731.439014
+    deployments:
+      VLLMDeployment:meta-llama--Llama-2-7b-chat-hf:
+        status: HEALTHY
+        replica_states:
+          RUNNING: 1
+        message: ''
+      Router:
+        status: HEALTHY
+        replica_states:
+          RUNNING: 2
+        message: ''
+```

--- a/ai-ml/gke-ray/rayserve/ap_falcon-40b.yaml
+++ b/ai-ml/gke-ray/rayserve/ap_falcon-40b.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/rayserve/ap_falcon-40b.yaml
+++ b/ai-ml/gke-ray/rayserve/ap_falcon-40b.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START gke_ai_ml_gke_ray_rayserve_ap_falcon_40b]
 apiVersion: ray.io/v1
 kind: RayService
 metadata:
@@ -129,3 +130,4 @@ spec:
           - name: worker-disk-vol
             persistentVolumeClaim:
               claimName: worker-disk
+# [END gke_ai_ml_gke_ray_rayserve_ap_falcon_40b]

--- a/ai-ml/gke-ray/rayserve/ap_falcon-40b.yaml
+++ b/ai-ml/gke-ray/rayserve/ap_falcon-40b.yaml
@@ -1,0 +1,131 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: ray.io/v1
+kind: RayService
+metadata:
+  name: rayllm
+spec:
+  serviceUnhealthySecondThreshold: 2400 # Config for the health check threshold for service. Default value is 60.
+  deploymentUnhealthySecondThreshold: 2400 # Config for the health check threshold for deployments. Default value is 60.
+  # setting the MODEL_ID env var on the workerGroupSpec did not work, it couldn't find it during exec
+  serveConfigV2: |
+    applications:
+    - name: falcon
+      route_prefix: /
+      import_path: model_nf4_mg:chat_app_nf4_mg
+      runtime_env:
+        env_vars:
+          MODEL_ID: "tiiuae/falcon-40b-instruct"
+          PYTHONPATH: "${HOME}/models"
+        pip: 
+        - bitsandbytes==0.42.0          
+      deployments:
+      - name: Chat
+        num_replicas: 1
+  rayClusterConfig:
+    # Ray head pod template
+    headGroupSpec:
+      # The `rayStartParams` are used to configure the `ray start` command.
+      # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
+      # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
+      rayStartParams:
+        resources: '"{\"accelerator_type_cpu\": 2}"'
+        dashboard-host: '0.0.0.0'
+        block: 'true'
+      #pod template
+      template:
+        spec:
+          containers:
+          - name: ray-head
+            image: anyscale/ray-llm:0.5.0
+            resources:
+              limits:
+                cpu: "2"
+                memory: "8Gi"
+              requests:
+                cpu: "2"
+                memory: "8Gi"
+            volumeMounts:
+            - mountPath: /home/ray/models
+              name: model                
+            ports:
+            - containerPort: 6379
+              name: gcs-server
+            - containerPort: 8265 # Ray dashboard
+              name: dashboard
+            - containerPort: 10001
+              name: client
+            - containerPort: 8000
+              name: serve
+          volumes:
+          - name: model
+            configMap:
+              name: quantized-model
+              items:
+              - key: model_nf4_mg.py
+                path: model_nf4_mg.py
+    workerGroupSpecs:
+    # the pod replicas in this group typed worker
+    - replicas: 1
+      minReplicas: 0
+      maxReplicas: 1
+      # logical group name, for this called small-group, also can be functional
+      groupName: gpu-group
+      rayStartParams:
+        block: 'true'
+        resources: '"{\"accelerator_type_cpu\": 22, \"accelerator_type_l4\": 2}"'
+      # pod template
+      template:
+        spec:
+          securityContext:
+            runAsUser: 1000
+            fsGroup: 100        
+          containers:
+          - name: llm
+            image: anyscale/ray-llm:0.5.0
+            env:
+            - name: HUGGING_FACE_HUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-secret
+                  key: hf_api_token
+            lifecycle:
+              preStop:
+                exec:
+                  command: ["/bin/sh","-c","ray stop"]
+            resources:
+              limits:
+                cpu: "22"
+                memory: "40Gi"
+                nvidia.com/gpu: "2"
+              requests:
+                cpu: "22"
+                memory: "40Gi"
+                nvidia.com/gpu: "2"
+            volumeMounts:
+            - mountPath: "/home/ray/.cache"
+              name: worker-disk-vol
+          # Please ensure the following taint has been applied to the GPU node in the cluster.
+          tolerations:
+            - key: "ray.io/node-type"
+              operator: "Equal"
+              value: "worker"
+              effect: "NoSchedule"
+          nodeSelector:
+            cloud.google.com/gke-accelerator: nvidia-l4
+          volumes:
+          - name: worker-disk-vol
+            persistentVolumeClaim:
+              claimName: worker-disk

--- a/ai-ml/gke-ray/rayserve/ap_falcon-7b.yaml
+++ b/ai-ml/gke-ray/rayserve/ap_falcon-7b.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/rayserve/ap_falcon-7b.yaml
+++ b/ai-ml/gke-ray/rayserve/ap_falcon-7b.yaml
@@ -1,0 +1,113 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: ray.io/v1
+kind: RayService
+metadata:
+  name: rayllm
+spec:
+  serviceUnhealthySecondThreshold: 1200 # Config for the health check threshold for service. Default value is 60.
+  deploymentUnhealthySecondThreshold: 1200 # Config for the health check threshold for deployments. Default value is 60.
+  serveConfigV2: |
+    applications:
+    - name: ray-llm
+      route_prefix: /
+      import_path: rayllm.backend:router_application
+      args:
+        models:
+        - "./models/tiiuae--falcon-7b-instruct.yaml"
+  rayClusterConfig:
+    # Ray head pod template
+    headGroupSpec:
+      # The `rayStartParams` are used to configure the `ray start` command.
+      # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
+      # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
+      rayStartParams:
+        resources: '"{\"accelerator_type_cpu\": 2}"'
+        dashboard-host: '0.0.0.0'
+        block: 'true'
+      #pod template
+      template:
+        spec:
+          containers:
+          - name: ray-head
+            image: anyscale/ray-llm:0.5.0
+            resources:
+              limits:
+                cpu: "2"
+                memory: "8Gi"
+              requests:
+                cpu: "2"
+                memory: "8Gi"
+            volumeMounts:
+            - mountPath: /home/ray/models
+              name: model                
+            ports:
+            - containerPort: 6379
+              name: gcs-server
+            - containerPort: 8265 # Ray dashboard
+              name: dashboard
+            - containerPort: 10001
+              name: client
+            - containerPort: 8000
+              name: serve
+          volumes:
+          - name: model
+            configMap:
+              name: falcon-7b-instruct
+              items:
+              - key: tiiuae--falcon-7b-instruct.yaml
+                path: tiiuae--falcon-7b-instruct.yaml    
+    workerGroupSpecs:
+    # the pod replicas in this group typed worker
+    - replicas: 1
+      minReplicas: 0
+      maxReplicas: 1
+      # logical group name, for this called small-group, also can be functional
+      groupName: gpu-group
+      rayStartParams:
+        block: 'true'
+        resources: '"{\"accelerator_type_cpu\": 20, \"accelerator_type_l4\": 1}"'
+      # pod template
+      template:
+        spec:
+          securityContext:
+            runAsUser: 1000
+            fsGroup: 100
+          containers:
+          - name: llm
+            image: anyscale/ray-llm:0.5.0
+            lifecycle:
+              preStop:
+                exec:
+                  command: ["/bin/sh","-c","ray stop"]
+            resources:
+              limits:
+                cpu: "20"
+                memory: "20Gi"
+                ephemeral-storage: "45Gi"
+                nvidia.com/gpu: "1"
+              requests:
+                cpu: "20"
+                memory: "20Gi"
+                ephemeral-storage: "45Gi"
+                nvidia.com/gpu: "1"
+          # Please ensure the following taint has been applied to the GPU node in the cluster.
+          tolerations:
+            - key: "ray.io/node-type"
+              operator: "Equal"
+              value: "worker"
+              effect: "NoSchedule"
+          nodeSelector:
+            cloud.google.com/gke-accelerator: nvidia-l4

--- a/ai-ml/gke-ray/rayserve/ap_falcon-7b.yaml
+++ b/ai-ml/gke-ray/rayserve/ap_falcon-7b.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START gke_ai_ml_gke_ray_rayserve_ap_falcon_7b]
 apiVersion: ray.io/v1
 kind: RayService
 metadata:
@@ -111,3 +112,4 @@ spec:
               effect: "NoSchedule"
           nodeSelector:
             cloud.google.com/gke-accelerator: nvidia-l4
+# [END gke_ai_ml_gke_ray_rayserve_ap_falcon_7b]

--- a/ai-ml/gke-ray/rayserve/ap_llama2-70b.yaml
+++ b/ai-ml/gke-ray/rayserve/ap_llama2-70b.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/rayserve/ap_llama2-70b.yaml
+++ b/ai-ml/gke-ray/rayserve/ap_llama2-70b.yaml
@@ -1,0 +1,131 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: ray.io/v1
+kind: RayService
+metadata:
+  name: rayllm
+spec:
+  serviceUnhealthySecondThreshold: 2400 # Config for the health check threshold for service. Default value is 60.
+  deploymentUnhealthySecondThreshold: 2400 # Config for the health check threshold for deployments. Default value is 60.
+  # setting the MODEL_ID env var on the workerGroupSpec did not work, it couldn't find it during exec
+  serveConfigV2: |
+    applications:
+    - name: llama-2
+      route_prefix: /
+      import_path: model_nf4_mg:chat_app_nf4_mg
+      runtime_env:
+        env_vars:
+          MODEL_ID: "meta-llama/Llama-2-70b-chat-hf"
+          PYTHONPATH: "${HOME}/models"
+        pip: 
+        - bitsandbytes==0.42.0          
+      deployments:
+      - name: Chat
+        num_replicas: 1
+  rayClusterConfig:
+    # Ray head pod template
+    headGroupSpec:
+      # The `rayStartParams` are used to configure the `ray start` command.
+      # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
+      # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
+      rayStartParams:
+        resources: '"{\"accelerator_type_cpu\": 2}"'
+        dashboard-host: '0.0.0.0'
+        block: 'true'
+      #pod template
+      template:
+        spec:
+          containers:
+          - name: ray-head
+            image: anyscale/ray-llm:0.5.0
+            resources:
+              limits:
+                cpu: "2"
+                memory: "8Gi"
+              requests:
+                cpu: "2"
+                memory: "8Gi"
+            volumeMounts:
+            - mountPath: /home/ray/models
+              name: model                
+            ports:
+            - containerPort: 6379
+              name: gcs-server
+            - containerPort: 8265 # Ray dashboard
+              name: dashboard
+            - containerPort: 10001
+              name: client
+            - containerPort: 8000
+              name: serve
+          volumes:
+          - name: model
+            configMap:
+              name: quantized-model
+              items:
+              - key: model_nf4_mg.py
+                path: model_nf4_mg.py
+    workerGroupSpecs:
+    # the pod replicas in this group typed worker
+    - replicas: 1
+      minReplicas: 0
+      maxReplicas: 1
+      # logical group name, for this called small-group, also can be functional
+      groupName: gpu-group
+      rayStartParams:
+        block: 'true'
+        resources: '"{\"accelerator_type_cpu\": 22, \"accelerator_type_l4\": 2}"'
+      # pod template
+      template:
+        spec:
+          securityContext:
+            runAsUser: 1000
+            fsGroup: 100        
+          containers:
+          - name: llm
+            image: anyscale/ray-llm:0.5.0
+            env:
+            - name: HUGGING_FACE_HUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-secret
+                  key: hf_api_token
+            lifecycle:
+              preStop:
+                exec:
+                  command: ["/bin/sh","-c","ray stop"]
+            resources:
+              limits:
+                cpu: "22"
+                memory: "40Gi"
+                nvidia.com/gpu: "2"
+              requests:
+                cpu: "22"
+                memory: "40Gi"
+                nvidia.com/gpu: "2"
+            volumeMounts:
+            - mountPath: "/home/ray/.cache"
+              name: worker-disk-vol
+          # Please ensure the following taint has been applied to the GPU node in the cluster.
+          tolerations:
+            - key: "ray.io/node-type"
+              operator: "Equal"
+              value: "worker"
+              effect: "NoSchedule"
+          nodeSelector:
+            cloud.google.com/gke-accelerator: nvidia-l4
+          volumes:
+          - name: worker-disk-vol
+            persistentVolumeClaim:
+              claimName: worker-disk

--- a/ai-ml/gke-ray/rayserve/ap_llama2-70b.yaml
+++ b/ai-ml/gke-ray/rayserve/ap_llama2-70b.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START gke_ai_ml_gke_ray_rayserve_ap_llama2_70b]
 apiVersion: ray.io/v1
 kind: RayService
 metadata:
@@ -129,3 +130,4 @@ spec:
           - name: worker-disk-vol
             persistentVolumeClaim:
               claimName: worker-disk
+# [END gke_ai_ml_gke_ray_rayserve_ap_llama2_70b]

--- a/ai-ml/gke-ray/rayserve/ap_llama2-7b.yaml
+++ b/ai-ml/gke-ray/rayserve/ap_llama2-7b.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/rayserve/ap_llama2-7b.yaml
+++ b/ai-ml/gke-ray/rayserve/ap_llama2-7b.yaml
@@ -1,0 +1,119 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: ray.io/v1
+kind: RayService
+metadata:
+  name: rayllm
+spec:
+  serviceUnhealthySecondThreshold: 1200 # Config for the health check threshold for service. Default value is 60.
+  deploymentUnhealthySecondThreshold: 1200 # Config for the health check threshold for deployments. Default value is 60.
+  serveConfigV2: |
+    applications:
+    - name: ray-llm
+      route_prefix: /
+      import_path: rayllm.backend:router_application
+      args:
+        models:
+        - "./models/meta-llama--Llama-2-7b-chat-hf.yaml"
+  rayClusterConfig:
+    # Ray head pod template
+    headGroupSpec:
+      # The `rayStartParams` are used to configure the `ray start` command.
+      # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
+      # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
+      rayStartParams:
+        resources: '"{\"accelerator_type_cpu\": 2}"'
+        dashboard-host: '0.0.0.0'
+        block: 'true'
+      #pod template
+      template:
+        spec:
+          containers:
+          - name: ray-head
+            image: anyscale/ray-llm:0.5.0
+            resources:
+              limits:
+                cpu: "2"
+                memory: "8Gi"
+              requests:
+                cpu: "2"
+                memory: "8Gi"
+            volumeMounts:
+            - mountPath: /home/ray/models
+              name: model           
+            ports:
+            - containerPort: 6379
+              name: gcs-server
+            - containerPort: 8265 # Ray dashboard
+              name: dashboard
+            - containerPort: 10001
+              name: client
+            - containerPort: 8000
+              name: serve
+          volumes:
+          - name: model
+            configMap:
+              name: meta-llama2-7b-chat-hf
+              items:
+              - key: meta-llama--Llama-2-7b-chat-hf.yaml
+                path: meta-llama--Llama-2-7b-chat-hf.yaml
+    workerGroupSpecs:
+    # the pod replicas in this group typed worker
+    - replicas: 1
+      minReplicas: 0
+      maxReplicas: 1
+      # logical group name, for this called small-group, also can be functional
+      groupName: gpu-group
+      rayStartParams:
+        block: 'true'
+        resources: '"{\"accelerator_type_cpu\": 20, \"accelerator_type_l4\": 1}"'
+      # pod template
+      template:
+        spec:
+          securityContext:
+            runAsUser: 1000
+            fsGroup: 100
+          containers:
+          - name: llm
+            image: anyscale/ray-llm:0.5.0
+            env:
+            - name: HUGGING_FACE_HUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-secret
+                  key: hf_api_token
+            lifecycle:
+              preStop:
+                exec:
+                  command: ["/bin/sh","-c","ray stop"]
+            resources:
+              limits:
+                cpu: "20"
+                memory: "20Gi"
+                ephemeral-storage: "20Gi"
+                nvidia.com/gpu: "1"
+              requests:
+                cpu: "20"
+                memory: "20Gi"
+                ephemeral-storage: "20Gi"
+                nvidia.com/gpu: "1"
+          # Please ensure the following taint has been applied to the GPU node in the cluster.
+          tolerations:
+            - key: "ray.io/node-type"
+              operator: "Equal"
+              value: "worker"
+              effect: "NoSchedule"
+          nodeSelector:
+            cloud.google.com/gke-accelerator: nvidia-l4

--- a/ai-ml/gke-ray/rayserve/ap_llama2-7b.yaml
+++ b/ai-ml/gke-ray/rayserve/ap_llama2-7b.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START gke_ai_ml_gke_ray_rayserve_ap_llama2_7b]
 apiVersion: ray.io/v1
 kind: RayService
 metadata:
@@ -117,3 +118,4 @@ spec:
               effect: "NoSchedule"
           nodeSelector:
             cloud.google.com/gke-accelerator: nvidia-l4
+# [END gke_ai_ml_gke_ray_rayserve_ap_llama2_7b]

--- a/ai-ml/gke-ray/rayserve/ap_pvc-rayservice.yaml
+++ b/ai-ml/gke-ray/rayserve/ap_pvc-rayservice.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/rayserve/ap_pvc-rayservice.yaml
+++ b/ai-ml/gke-ray/rayserve/ap_pvc-rayservice.yaml
@@ -1,0 +1,25 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: worker-disk
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 200Gi
+  storageClassName: standard-rwo

--- a/ai-ml/gke-ray/rayserve/ap_pvc-rayservice.yaml
+++ b/ai-ml/gke-ray/rayserve/ap_pvc-rayservice.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START gke_ai_ml_gke_ray_rayserve_ap_pvc_rayservice]
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -23,3 +24,4 @@ spec:
     requests:
       storage: 200Gi
   storageClassName: standard-rwo
+# [END gke_ai_ml_gke_ray_rayserve_ap_pvc_rayservice]

--- a/ai-ml/gke-ray/rayserve/falcon-40b.yaml
+++ b/ai-ml/gke-ray/rayserve/falcon-40b.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/rayserve/falcon-40b.yaml
+++ b/ai-ml/gke-ray/rayserve/falcon-40b.yaml
@@ -1,0 +1,121 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: ray.io/v1
+kind: RayService
+metadata:
+  name: rayllm
+spec:
+  serviceUnhealthySecondThreshold: 2400 # Config for the health check threshold for service. Default value is 60.
+  deploymentUnhealthySecondThreshold: 2400 # Config for the health check threshold for deployments. Default value is 60.
+  # setting the MODEL_ID env var on the workerGroupSpec did not work, it couldn't find it during exec
+  serveConfigV2: |
+    applications:
+    - name: falcon
+      route_prefix: /
+      import_path: model_nf4_mg:chat_app_nf4_mg
+      runtime_env:
+        env_vars:
+          MODEL_ID: "tiiuae/falcon-40b-instruct"
+          PYTHONPATH: "${HOME}/models"
+        pip: 
+        - bitsandbytes==0.42.0
+      deployments:
+      - name: Chat
+        num_replicas: 1
+  rayClusterConfig:
+    # Ray head pod template
+    headGroupSpec:
+      # The `rayStartParams` are used to configure the `ray start` command.
+      # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
+      # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
+      rayStartParams:
+        resources: '"{\"accelerator_type_cpu\": 2}"'
+        dashboard-host: '0.0.0.0'
+        block: 'true'
+      #pod template
+      template:
+        spec:
+          containers:
+          - name: ray-head
+            image: anyscale/ray-llm:0.5.0
+            resources:
+              limits:
+                cpu: "2"
+                memory: "8Gi"
+              requests:
+                cpu: "2"
+                memory: "8Gi"
+            volumeMounts:
+            - mountPath: /home/ray/models
+              name: model                
+            ports:
+            - containerPort: 6379
+              name: gcs-server
+            - containerPort: 8265 # Ray dashboard
+              name: dashboard
+            - containerPort: 10001
+              name: client
+            - containerPort: 8000
+              name: serve
+          volumes:
+          - name: model
+            configMap:
+              name: quantized-model
+              items:
+              - key: model_nf4_mg.py
+                path: model_nf4_mg.py              
+    workerGroupSpecs:
+    # the pod replicas in this group typed worker
+    - replicas: 1
+      minReplicas: 0
+      maxReplicas: 1
+      # logical group name, for this called small-group, also can be functional
+      groupName: gpu-group
+      rayStartParams:
+        block: 'true'
+        resources: '"{\"accelerator_type_cpu\": 22, \"accelerator_type_l4\": 2}"'
+      # pod template
+      template:
+        spec:
+          containers:
+          - name: llm
+            image: anyscale/ray-llm:0.5.0
+            env:
+            - name: HUGGING_FACE_HUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-secret
+                  key: hf_api_token
+            lifecycle:
+              preStop:
+                exec:
+                  command: ["/bin/sh","-c","ray stop"]
+            resources:
+              limits:
+                cpu: "22"
+                memory: "40Gi"
+                nvidia.com/gpu: "2"
+              requests:
+                cpu: "22"
+                memory: "40Gi"
+                nvidia.com/gpu: "2"
+          # Please ensure the following taint has been applied to the GPU node in the cluster.
+          tolerations:
+            - key: "ray.io/node-type"
+              operator: "Equal"
+              value: "worker"
+              effect: "NoSchedule"
+          nodeSelector:
+            cloud.google.com/gke-accelerator: nvidia-l4

--- a/ai-ml/gke-ray/rayserve/falcon-40b.yaml
+++ b/ai-ml/gke-ray/rayserve/falcon-40b.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START gke_ai_ml_gke_ray_rayserve_falcon_40b]
 apiVersion: ray.io/v1
 kind: RayService
 metadata:
@@ -119,3 +120,4 @@ spec:
               effect: "NoSchedule"
           nodeSelector:
             cloud.google.com/gke-accelerator: nvidia-l4
+# [END gke_ai_ml_gke_ray_rayserve_falcon_40b]

--- a/ai-ml/gke-ray/rayserve/falcon-7b.yaml
+++ b/ai-ml/gke-ray/rayserve/falcon-7b.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/rayserve/falcon-7b.yaml
+++ b/ai-ml/gke-ray/rayserve/falcon-7b.yaml
@@ -1,0 +1,108 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: ray.io/v1
+kind: RayService
+metadata:
+  name: rayllm
+spec:
+  serviceUnhealthySecondThreshold: 1200 # Config for the health check threshold for service. Default value is 60.
+  deploymentUnhealthySecondThreshold: 1200 # Config for the health check threshold for deployments. Default value is 60.
+  serveConfigV2: |
+    applications:
+    - name: ray-llm
+      route_prefix: /
+      import_path: rayllm.backend:router_application
+      args:
+        models:
+        - "./models/tiiuae--falcon-7b-instruct.yaml"
+  rayClusterConfig:
+    # Ray head pod template
+    headGroupSpec:
+      # The `rayStartParams` are used to configure the `ray start` command.
+      # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
+      # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
+      rayStartParams:
+        resources: '"{\"accelerator_type_cpu\": 2}"'
+        dashboard-host: '0.0.0.0'
+        block: 'true'
+      #pod template
+      template:
+        spec:
+          containers:
+          - name: ray-head
+            image: anyscale/ray-llm:0.5.0
+            resources:
+              limits:
+                cpu: "2"
+                memory: "8Gi"
+              requests:
+                cpu: "2"
+                memory: "8Gi"
+            volumeMounts:
+            - mountPath: /home/ray/models
+              name: model                
+            ports:
+            - containerPort: 6379
+              name: gcs-server
+            - containerPort: 8265 # Ray dashboard
+              name: dashboard
+            - containerPort: 10001
+              name: client
+            - containerPort: 8000
+              name: serve
+          volumes:
+          - name: model
+            configMap:
+              name: falcon-7b-instruct
+              items:
+              - key: tiiuae--falcon-7b-instruct.yaml
+                path: tiiuae--falcon-7b-instruct.yaml              
+    workerGroupSpecs:
+    # the pod replicas in this group typed worker
+    - replicas: 1
+      minReplicas: 0
+      maxReplicas: 1
+      # logical group name, for this called small-group, also can be functional
+      groupName: gpu-group
+      rayStartParams:
+        block: 'true'
+        resources: '"{\"accelerator_type_cpu\": 20, \"accelerator_type_l4\": 1}"'
+      # pod template
+      template:
+        spec:
+          containers:
+          - name: llm
+            image: anyscale/ray-llm:0.5.0
+            lifecycle:
+              preStop:
+                exec:
+                  command: ["/bin/sh","-c","ray stop"]
+            resources:
+              limits:
+                cpu: "20"
+                memory: "20Gi"
+                nvidia.com/gpu: "1"
+              requests:
+                cpu: "20"
+                memory: "20Gi"
+                nvidia.com/gpu: "1"
+          # Please ensure the following taint has been applied to the GPU node in the cluster.
+          tolerations:
+            - key: "ray.io/node-type"
+              operator: "Equal"
+              value: "worker"
+              effect: "NoSchedule"
+          nodeSelector:
+            cloud.google.com/gke-accelerator: nvidia-l4

--- a/ai-ml/gke-ray/rayserve/falcon-7b.yaml
+++ b/ai-ml/gke-ray/rayserve/falcon-7b.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START gke_ai_ml_gke_ray_rayserve_falcon_7b]
 apiVersion: ray.io/v1
 kind: RayService
 metadata:
@@ -106,3 +107,4 @@ spec:
               effect: "NoSchedule"
           nodeSelector:
             cloud.google.com/gke-accelerator: nvidia-l4
+# [END gke_ai_ml_gke_ray_rayserve_falcon_7b]

--- a/ai-ml/gke-ray/rayserve/gradio.yaml
+++ b/ai-ml/gke-ray/rayserve/gradio.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/rayserve/gradio.yaml
+++ b/ai-ml/gke-ray/rayserve/gradio.yaml
@@ -1,0 +1,55 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gradio
+  labels:
+    app: gradio
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gradio
+  template:
+    metadata:
+      labels:
+        app: gradio
+    spec:
+      containers:
+      - name: gradio
+        image: us-docker.pkg.dev/google-samples/containers/gke/gradio-app:v1.0.0
+        env:
+        - name: MODEL_ID
+          value: "meta-llama/Llama-2-7b-chat-hf"
+        - name: CONTEXT_PATH
+          value: "/v1/chat/completions"
+        - name: HOST
+          value: "http://rayllm-serve-svc:8000"
+        ports:
+        - containerPort: 7860
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gradio
+spec:
+  selector:
+    app: gradio
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 7860
+  type: LoadBalancer

--- a/ai-ml/gke-ray/rayserve/gradio.yaml
+++ b/ai-ml/gke-ray/rayserve/gradio.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START gke_ai_ml_gke_ray_rayserve_gradio]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -53,3 +54,4 @@ spec:
       port: 80
       targetPort: 7860
   type: LoadBalancer
+# [END gke_ai_ml_gke_ray_rayserve_gradio]

--- a/ai-ml/gke-ray/rayserve/ingress/README.md
+++ b/ai-ml/gke-ray/rayserve/ingress/README.md
@@ -1,0 +1,39 @@
+# Expose your serve endpoint
+
+> NOTE: This is just an example for testing. One scenario you would expose it as an [internal IP](https://cloud.google.com/kubernetes-engine/docs/how-to/deploying-gateways#deploy_a_regional_internal_gateway) that you would call within your VPC. Another scenario if external, you would have Google Cloud [manage a certificate](https://cloud.google.com/kubernetes-engine/docs/how-to/deploying-gateways#deploy_a_global_external_gateway) for you or provide your own.
+
+## Deploy the resources for your gateway
+- The gateway resource
+```zsh
+kubectl apply -f gateway.yaml
+```
+
+- Deploy the HTTPRoute resource that will route traffic to your aviary endpoint
+```zsh
+kubectl apply -f httproute.yaml
+```
+
+- Deploy a custom health check policy because the aviary endpoint does not respond with a 200 on "/", however when deployed "/-/routes" does
+```zsh
+kubectl apply -f healthcheckpolicy.yaml
+```
+
+- Check to see what the external IP is in this example
+```zsh
+EXTERNAL_IP=$(kubectl get gateways.gateway.networking.k8s.io external-http -o=jsonpath="{.status.addresses[0].value}")
+echo ${EXTERNAL_IP}
+```
+
+- Try the call to your ray serve endpoint now
+```zsh
+curl http://${EXTERNAL_IP}/meta-llama--Llama-2-7b-chat-hf/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "meta-llama/Llama-2-7b-chat-hf",
+    "messages": [
+      {"role": "system", "content": "You are a helpful assistant."},
+      {"role": "user", "content": "What are the top 5 most popular programming languages? Please be brief."}
+    ],
+    "temperature": 0.7
+  }'
+```

--- a/ai-ml/gke-ray/rayserve/ingress/gateway.yaml
+++ b/ai-ml/gke-ray/rayserve/ingress/gateway.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/rayserve/ingress/gateway.yaml
+++ b/ai-ml/gke-ray/rayserve/ingress/gateway.yaml
@@ -1,0 +1,24 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1beta1
+metadata:
+  name: external-http
+spec:
+  gatewayClassName: gke-l7-global-external-managed
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80

--- a/ai-ml/gke-ray/rayserve/ingress/healthcheckpolicy.yaml
+++ b/ai-ml/gke-ray/rayserve/ingress/healthcheckpolicy.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/rayserve/ingress/healthcheckpolicy.yaml
+++ b/ai-ml/gke-ray/rayserve/ingress/healthcheckpolicy.yaml
@@ -1,0 +1,35 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: endpoint-lb-healthcheck
+spec:
+  default:
+    checkIntervalSec: 30
+    timeoutSec: 10
+    healthyThreshold: 3
+    unhealthyThreshold: 3
+    logConfig:
+      enabled: true
+    config:
+      type: HTTP
+      httpHealthCheck:
+        port: 8000
+        requestPath: "/-/routes"
+  targetRef:
+    group: ""
+    kind: Service
+    name: rayllm-head-svc

--- a/ai-ml/gke-ray/rayserve/ingress/httproute.yaml
+++ b/ai-ml/gke-ray/rayserve/ingress/httproute.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/rayserve/ingress/httproute.yaml
+++ b/ai-ml/gke-ray/rayserve/ingress/httproute.yaml
@@ -1,0 +1,26 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1beta1
+metadata:
+  name: serve-api-endpoint
+spec:
+  parentRefs:
+  - kind: Gateway
+    name: external-http
+  rules:
+  - backendRefs:
+    - name: rayllm-head-svc
+      port: 8000

--- a/ai-ml/gke-ray/rayserve/llama2-70b.yaml
+++ b/ai-ml/gke-ray/rayserve/llama2-70b.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/rayserve/llama2-70b.yaml
+++ b/ai-ml/gke-ray/rayserve/llama2-70b.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START gke_ai_ml_gke_ray_rayserve_llama2_70b]
 apiVersion: ray.io/v1
 kind: RayService
 metadata:
@@ -119,3 +120,4 @@ spec:
               effect: "NoSchedule"
           nodeSelector:
             cloud.google.com/gke-accelerator: nvidia-l4
+# [END gke_ai_ml_gke_ray_rayserve_llama2_70b]

--- a/ai-ml/gke-ray/rayserve/llama2-70b.yaml
+++ b/ai-ml/gke-ray/rayserve/llama2-70b.yaml
@@ -1,0 +1,121 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: ray.io/v1
+kind: RayService
+metadata:
+  name: rayllm
+spec:
+  serviceUnhealthySecondThreshold: 2400 # Config for the health check threshold for service. Default value is 60.
+  deploymentUnhealthySecondThreshold: 2400 # Config for the health check threshold for deployments. Default value is 60.
+  # setting the MODEL_ID env var on the workerGroupSpec did not work, it couldn't find it during exec
+  serveConfigV2: |
+    applications:
+    - name: llama-2
+      route_prefix: /
+      import_path: model_nf4_mg:chat_app_nf4_mg
+      runtime_env:
+        env_vars:
+          MODEL_ID: "meta-llama/Llama-2-70b-chat-hf"
+          PYTHONPATH: "${HOME}/models"
+        pip: 
+        - bitsandbytes==0.42.0
+      deployments:
+      - name: Chat
+        num_replicas: 1
+  rayClusterConfig:
+    # Ray head pod template
+    headGroupSpec:
+      # The `rayStartParams` are used to configure the `ray start` command.
+      # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
+      # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
+      rayStartParams:
+        resources: '"{\"accelerator_type_cpu\": 2}"'
+        dashboard-host: '0.0.0.0'
+        block: 'true'
+      #pod template
+      template:
+        spec:
+          containers:
+          - name: ray-head
+            image: anyscale/ray-llm:0.5.0
+            resources:
+              limits:
+                cpu: "2"
+                memory: "8Gi"
+              requests:
+                cpu: "2"
+                memory: "8Gi"
+            volumeMounts:
+            - mountPath: /home/ray/models
+              name: model
+            ports:
+            - containerPort: 6379
+              name: gcs-server
+            - containerPort: 8265 # Ray dashboard
+              name: dashboard
+            - containerPort: 10001
+              name: client
+            - containerPort: 8000
+              name: serve
+          volumes:
+          - name: model
+            configMap:
+              name: quantized-model
+              items:
+              - key: model_nf4_mg.py
+                path: model_nf4_mg.py              
+    workerGroupSpecs:
+    # the pod replicas in this group typed worker
+    - replicas: 1
+      minReplicas: 0
+      maxReplicas: 1
+      # logical group name, for this called small-group, also can be functional
+      groupName: gpu-group
+      rayStartParams:
+        block: 'true'
+        resources: '"{\"accelerator_type_cpu\": 22, \"accelerator_type_l4\": 2}"'
+      # pod template
+      template:
+        spec:
+          containers:
+          - name: llm
+            image: anyscale/ray-llm:0.5.0
+            env:
+            - name: HUGGING_FACE_HUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-secret
+                  key: hf_api_token
+            lifecycle:
+              preStop:
+                exec:
+                  command: ["/bin/sh","-c","ray stop"]
+            resources:
+              limits:
+                cpu: "22"
+                memory: "40Gi"
+                nvidia.com/gpu: "2"
+              requests:
+                cpu: "22"
+                memory: "40Gi"
+                nvidia.com/gpu: "2"
+          # Please ensure the following taint has been applied to the GPU node in the cluster.
+          tolerations:
+            - key: "ray.io/node-type"
+              operator: "Equal"
+              value: "worker"
+              effect: "NoSchedule"
+          nodeSelector:
+            cloud.google.com/gke-accelerator: nvidia-l4

--- a/ai-ml/gke-ray/rayserve/llama2-7b.yaml
+++ b/ai-ml/gke-ray/rayserve/llama2-7b.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/rayserve/llama2-7b.yaml
+++ b/ai-ml/gke-ray/rayserve/llama2-7b.yaml
@@ -1,0 +1,114 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: ray.io/v1
+kind: RayService
+metadata:
+  name: rayllm
+spec:
+  serviceUnhealthySecondThreshold: 1200 # Config for the health check threshold for service. Default value is 60.
+  deploymentUnhealthySecondThreshold: 1200 # Config for the health check threshold for deployments. Default value is 60.
+  serveConfigV2: |
+    applications:
+    - name: ray-llm
+      route_prefix: /
+      import_path: rayllm.backend:router_application
+      args:
+        models:
+        - "./models/meta-llama--Llama-2-7b-chat-hf.yaml"
+  rayClusterConfig:
+    # Ray head pod template
+    headGroupSpec:
+      # The `rayStartParams` are used to configure the `ray start` command.
+      # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
+      # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
+      rayStartParams:
+        resources: '"{\"accelerator_type_cpu\": 2}"'
+        dashboard-host: '0.0.0.0'
+        block: 'true'
+      #pod template
+      template:
+        spec:
+          containers:
+          - name: ray-head
+            image: anyscale/ray-llm:0.5.0
+            resources:
+              limits:
+                cpu: "2"
+                memory: "8Gi"
+              requests:
+                cpu: "2"
+                memory: "8Gi"
+            volumeMounts:
+            - mountPath: /home/ray/models
+              name: model                
+            ports:
+            - containerPort: 6379
+              name: gcs-server
+            - containerPort: 8265 # Ray dashboard
+              name: dashboard
+            - containerPort: 10001
+              name: client
+            - containerPort: 8000
+              name: serve
+          volumes:
+          - name: model
+            configMap:
+              name: meta-llama2-7b-chat-hf
+              items:
+              - key: meta-llama--Llama-2-7b-chat-hf.yaml
+                path: meta-llama--Llama-2-7b-chat-hf.yaml              
+    workerGroupSpecs:
+    # the pod replicas in this group typed worker
+    - replicas: 1
+      minReplicas: 0
+      maxReplicas: 1
+      # logical group name, for this called small-group, also can be functional
+      groupName: gpu-group
+      rayStartParams:
+        block: 'true'
+        resources: '"{\"accelerator_type_cpu\": 20, \"accelerator_type_l4\": 1}"'
+      # pod template
+      template:
+        spec:
+          containers:
+          - name: llm
+            image: anyscale/ray-llm:0.5.0
+            env:
+            - name: HUGGING_FACE_HUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-secret
+                  key: hf_api_token
+            lifecycle:
+              preStop:
+                exec:
+                  command: ["/bin/sh","-c","ray stop"]
+            resources:
+              limits:
+                cpu: "20"
+                memory: "20Gi"
+                nvidia.com/gpu: "1"
+              requests:
+                cpu: "20"
+                memory: "20Gi"
+                nvidia.com/gpu: "1"
+          # Please ensure the following taint has been applied to the GPU node in the cluster.
+          tolerations:
+            - key: "ray.io/node-type"
+              operator: "Equal"
+              value: "worker"
+              effect: "NoSchedule"
+          nodeSelector:
+            cloud.google.com/gke-accelerator: nvidia-l4

--- a/ai-ml/gke-ray/rayserve/llama2-7b.yaml
+++ b/ai-ml/gke-ray/rayserve/llama2-7b.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START gke_ai_ml_gke_ray_rayserve_llama2_7b]
 apiVersion: ray.io/v1
 kind: RayService
 metadata:
@@ -112,3 +113,4 @@ spec:
               effect: "NoSchedule"
           nodeSelector:
             cloud.google.com/gke-accelerator: nvidia-l4
+# [END gke_ai_ml_gke_ray_rayserve_llama2_7b]

--- a/ai-ml/gke-ray/rayserve/models/falcon-7b-instruct.yaml
+++ b/ai-ml/gke-ray/rayserve/models/falcon-7b-instruct.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/rayserve/models/falcon-7b-instruct.yaml
+++ b/ai-ml/gke-ray/rayserve/models/falcon-7b-instruct.yaml
@@ -1,0 +1,61 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: falcon-7b-instruct
+data:
+  tiiuae--falcon-7b-instruct.yaml: |
+    deployment_config:
+      autoscaling_config:
+        min_replicas: 1
+        initial_replicas: 1
+        max_replicas: 8
+        target_num_ongoing_requests_per_replica: 24
+        metrics_interval_s: 10.0
+        look_back_period_s: 30.0
+        smoothing_factor: 0.5
+        downscale_delay_s: 300.0
+        upscale_delay_s: 15.0
+      max_concurrent_queries: 64
+      ray_actor_options:
+        resources:
+          accelerator_type_l4: 0.01
+    engine_config:
+      model_id: tiiuae/falcon-7b-instruct
+      hf_model_id: tiiuae/falcon-7b-instruct
+      type: VLLMEngine
+      engine_kwargs:
+        trust_remote_code: false
+        max_num_batched_tokens: 2048
+        max_num_seqs: 64
+        gpu_memory_utilization: 0.9
+      max_total_tokens: 2048
+      generation:
+        prompt_format:
+          system: "{instruction}\n\n"
+          assistant: " {instruction} </s><s>"
+          trailing_assistant: ""
+          user: "[INST] {system}{instruction}"
+          system_in_user: true
+          default_system_message: ""
+        stopping_sequences: ["<unk>"]
+    scaling_config:
+      num_workers: 1
+      num_gpus_per_worker: 1
+      num_cpus_per_worker: 3
+      placement_strategy: "STRICT_PACK"
+      resources_per_worker:
+        accelerator_type_l4: 0.01

--- a/ai-ml/gke-ray/rayserve/models/falcon-7b-instruct.yaml
+++ b/ai-ml/gke-ray/rayserve/models/falcon-7b-instruct.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START gke_ai_ml_gke_ray_rayserve_models_falcon_7b_instruct]
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -59,3 +60,4 @@ data:
       placement_strategy: "STRICT_PACK"
       resources_per_worker:
         accelerator_type_l4: 0.01
+# [END gke_ai_ml_gke_ray_rayserve_models_falcon_7b_instruct]

--- a/ai-ml/gke-ray/rayserve/models/llama2-7b-chat-hf.yaml
+++ b/ai-ml/gke-ray/rayserve/models/llama2-7b-chat-hf.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/rayserve/models/llama2-7b-chat-hf.yaml
+++ b/ai-ml/gke-ray/rayserve/models/llama2-7b-chat-hf.yaml
@@ -1,0 +1,61 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: meta-llama2-7b-chat-hf
+data:
+  meta-llama--Llama-2-7b-chat-hf.yaml: |
+    deployment_config:
+      autoscaling_config:
+        min_replicas: 1
+        initial_replicas: 1
+        max_replicas: 8
+        target_num_ongoing_requests_per_replica: 24
+        metrics_interval_s: 10.0
+        look_back_period_s: 30.0
+        smoothing_factor: 0.5
+        downscale_delay_s: 300.0
+        upscale_delay_s: 15.0
+      max_concurrent_queries: 64
+      ray_actor_options:
+        resources:
+          accelerator_type_l4: 0.01
+    engine_config:
+      model_id: meta-llama/Llama-2-7b-chat-hf
+      hf_model_id: meta-llama/Llama-2-7b-chat-hf
+      type: VLLMEngine
+      engine_kwargs:
+        trust_remote_code: true
+        max_num_batched_tokens: 4096
+        max_num_seqs: 64
+        gpu_memory_utilization: 0.9
+      max_total_tokens: 4096
+      generation:
+        prompt_format:
+          system: "<<SYS>>\n{instruction}\n<</SYS>>\n\n"
+          assistant: " {instruction} </s><s>"
+          trailing_assistant: ""
+          user: "[INST] {system}{instruction} [/INST]"
+          system_in_user: true
+          default_system_message: ""
+        stopping_sequences: ["<unk>"]
+    scaling_config:
+      num_workers: 1
+      num_gpus_per_worker: 1
+      num_cpus_per_worker: 3
+      placement_strategy: "STRICT_PACK"
+      resources_per_worker:
+        accelerator_type_l4: 0.01

--- a/ai-ml/gke-ray/rayserve/models/llama2-7b-chat-hf.yaml
+++ b/ai-ml/gke-ray/rayserve/models/llama2-7b-chat-hf.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START gke_ai_ml_gke_ray_rayserve_models_llama2_7b_chat_hf]
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -59,3 +60,4 @@ data:
       placement_strategy: "STRICT_PACK"
       resources_per_worker:
         accelerator_type_l4: 0.01
+# [END gke_ai_ml_gke_ray_rayserve_models_llama2_7b_chat_hf]

--- a/ai-ml/gke-ray/rayserve/models/quantized-model.yaml
+++ b/ai-ml/gke-ray/rayserve/models/quantized-model.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ai-ml/gke-ray/rayserve/models/quantized-model.yaml
+++ b/ai-ml/gke-ray/rayserve/models/quantized-model.yaml
@@ -1,0 +1,102 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: quantized-model
+data:
+  model_nf4_mg.py: |
+    import ray
+    import os
+    import transformers
+    import torch
+    from ray import serve
+    from fastapi import FastAPI, Body
+    from transformers import AutoTokenizer, BitsAndBytesConfig, AutoModelForCausalLM, AutoConfig
+    from pydantic import BaseModel
+
+    ## quantized with bitsandbytes nf4, Multi-gpu single-host
+
+    class Query(BaseModel):
+        text: str
+
+    # validator error - pip install pydantic==1.10.9
+
+    app = FastAPI()
+
+    model_id = os.environ["MODEL_ID"]
+
+    @serve.deployment(num_replicas=1, ray_actor_options={"num_cpus": 20, "num_gpus": 2})
+
+    @serve.ingress(app)
+    class Chat:
+        tokenizer = ""
+        pipeline = ""
+        
+        def __init__(self):
+            # Load bnb4
+            nf4_config = BitsAndBytesConfig(
+                load_in_4bit=True,
+                bnb_4bit_quant_type="nf4",
+                bnb_4bit_use_double_quant=True,
+                bnb_4bit_compute_dtype=torch.bfloat16,
+                llm_int8_enable_fp32_cpu_offload=True
+            )
+              
+            # Load model config
+            self.tokenizer = AutoTokenizer.from_pretrained(
+                model_id, 
+                token=os.environ["HUGGING_FACE_HUB_TOKEN"]
+            )
+
+            # load the model with quantization
+            model_nf4 = AutoModelForCausalLM.from_pretrained(
+                model_id,
+                quantization_config=nf4_config,
+                device_map="auto",
+                token=os.environ["HUGGING_FACE_HUB_TOKEN"]
+            )
+
+            # prepare the pipeline for inferencing
+            self.pipeline = transformers.pipeline(
+                "text-generation",
+                model=model_nf4,
+                torch_dtype=torch.float16,
+                device_map="auto",
+                tokenizer=self.tokenizer,
+                token=os.environ["HUGGING_FACE_HUB_TOKEN"]
+            )
+
+        @app.post("/")
+        async def chat(self, payload: dict = Body(...)) -> str:
+            # Run inference
+            print("query text: " + payload['text'])
+            sequences = self.pipeline(
+                payload['text'],
+                do_sample=True,
+                top_k=10,
+                num_return_sequences=1,
+                eos_token_id=self.tokenizer.eos_token_id,
+                max_length=200        
+            )
+
+            val = ""
+            for seq in sequences:
+                val = seq['generated_text']
+                print("val: " + val)
+
+            return val 
+
+    chat_app_nf4_mg = Chat.bind()

--- a/ai-ml/gke-ray/rayserve/models/quantized-model.yaml
+++ b/ai-ml/gke-ray/rayserve/models/quantized-model.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# [START gke_ai_ml_gke_ray_rayserve_models_quantized_model]
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -100,3 +101,4 @@ data:
             return val 
 
     chat_app_nf4_mg = Chat.bind()
+# [END gke_ai_ml_gke_ray_rayserve_models_quantized_model]


### PR DESCRIPTION
This PR refactors ray service / llm on GKE examples from the ai-on-gke repo.

This includes sample terraform to deploy gke and the kuberay operator
This includes the ray service and ray llm respective examples for serving llama2 and falcon models.