### PR TITLE
Update image versions in languages quickstarts

### DIFF
--- a/quickstarts/languages/go/Dockerfile
+++ b/quickstarts/languages/go/Dockerfile
@@ -16,7 +16,7 @@
 # Use the offical Go image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.21.0 as builder
+FROM golang:1.22.0 as builder
 WORKDIR /app
 
 # Initialize a new Go module.

--- a/quickstarts/languages/nodejs/Dockerfile
+++ b/quickstarts/languages/nodejs/Dockerfile
@@ -15,7 +15,7 @@
 # [START gke_quickstarts_languages_nodejs_dockerfile]
 # Use the official lightweight Node.js 16 image.
 # https://hub.docker.com/_/node
-FROM node:17-slim
+FROM node:21-slim
 
 # Create and change to the app directory.
 WORKDIR /usr/src/app

--- a/quickstarts/languages/php/Dockerfile
+++ b/quickstarts/languages/php/Dockerfile
@@ -15,7 +15,7 @@
 # [START gke_quickstarts_languages_php_dockerfile]
 # Use the official PHP 7.4 image.
 # https://hub.docker.com/_/php
-FROM php:7.4-apache
+FROM php:8.2-apache
 
 # Copy local code to the container image.
 COPY index.php /var/www/html/

--- a/quickstarts/languages/python/Dockerfile
+++ b/quickstarts/languages/python/Dockerfile
@@ -15,7 +15,7 @@
 # [START gke_quickstarts_languages_python_dockerfile]
 # Use the official lightweight Python image.
 # https://hub.docker.com/_/python
-FROM python:3.7-slim
+FROM python:3.12-slim
 
 # Copy local code to the container image.
 ENV APP_HOME /app

--- a/quickstarts/languages/ruby/Dockerfile
+++ b/quickstarts/languages/ruby/Dockerfile
@@ -1,6 +1,6 @@
 # Use the official lightweight Ruby image.
 # https://hub.docker.com/_/ruby
-FROM ruby:2.5-slim
+FROM ruby:3.3-slim
 
 # Install production dependencies.
 WORKDIR /usr/src/app


### PR DESCRIPTION
This PR bumps the base images used in languages quickstarts:
- Go: `1.21` -> `1.22`
- Node: `17` -> `21`
- PHP: `7.4` -> `8.2`
- Python: `3.7` -> `3.12`
- Ruby: `2.5` -> `3.3`

Internal issue #333283527

### Testing

Go
```
~docker run -p 8080:8080 qs-go
2024/04/11 18:46:47 Listening on localhost:8080
```
```
~curl localhost:8080
Hello World!
```

Node
```
~docker run -p 8080:8080 qs-node

> gke-helloworld@1.0.0 start
> node index.js

Hello world listening on port 8080
```
```
~curl localhost:8080
Hello World!
```

PHP
```
~docker run -p 8080:8080 qs-php
AH00558: apache2: Could not reliably determine the server's fully qualified domain name, using 192.168.9.2. Set the 'ServerName' directive globally to suppress this message
AH00558: apache2: Could not reliably determine the server's fully qualified domain name, using 192.168.9.2. Set the 'ServerName' directive globally to suppress this message
[Thu Apr 11 18:57:19.955142 2024] [mpm_prefork:notice] [pid 1] AH00163: Apache/2.4.57 (Debian) PHP/8.2.17 configured -- resuming normal operations
[Thu Apr 11 18:57:19.955230 2024] [core:notice] [pid 1] AH00094: Command line: 'apache2 -D FOREGROUND'
```
```
~curl localhost:8080
Hello World!
```

Python
```
~docker run -p 8080:8080 qs-py
[2024-04-11 18:58:48 +0000] [1] [INFO] Starting gunicorn 21.2.0
[2024-04-11 18:58:48 +0000] [1] [INFO] Listening at: http://0.0.0.0:8080 (1)
[2024-04-11 18:58:48 +0000] [1] [INFO] Using worker: gthread
[2024-04-11 18:58:48 +0000] [7] [INFO] Booting worker with pid: 7
```
```
~curl localhost:8080
Hello World!
```