### PR TITLE
Fix apiversion to autoscaling/v2

### DIFF
--- a/cost-optimization/gke-scheduled-autoscaler/k8s/hpa-example.yaml
+++ b/cost-optimization/gke-scheduled-autoscaler/k8s/hpa-example.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: php-apache

--- a/cost-optimization/gke-scheduled-autoscaler/k8s/scheduled-autoscaler/hpa-example.yaml
+++ b/cost-optimization/gke-scheduled-autoscaler/k8s/scheduled-autoscaler/hpa-example.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: php-apache

--- a/databases/cloud-pubsub/deployment/pubsub-hpa.yaml
+++ b/databases/cloud-pubsub/deployment/pubsub-hpa.yaml
@@ -15,7 +15,7 @@
 
 # [START gke_deployment_pubsub_hpa_horizontalpodautoscaler_pubsub]
 # [START container_pubsub_horizontal_pod_autoscaler]
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: pubsub

--- a/observability/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd-hpa.yaml
+++ b/observability/custom-metrics-autoscaling/direct-to-sd/custom-metrics-sd-hpa.yaml
@@ -15,7 +15,7 @@
 
 # [START gke_direct_to_sd_custom_metrics_sd_hpa_horizontalpodautoscaler_custom_metric_sd]
 # [START container_custom_metrics_direct_horizontal_pod_autoscaler]
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: custom-metric-sd

--- a/observability/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd-hpa.yaml
+++ b/observability/custom-metrics-autoscaling/prometheus-to-sd/custom-metrics-prometheus-sd-hpa.yaml
@@ -15,7 +15,7 @@
 
 # [START gke_prometheus_to_sd_custom_metrics_prometheus_sd_hpa_horizontalpodautoscaler_custom_prometheus_hpa]
 # [START container_custom_metrics_prometheus_horizontal_pod_autoscaler]
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: custom-prometheus-hpa

--- a/observability/workload-metrics/manifests/workload-metrics-hpa.yaml
+++ b/observability/workload-metrics/manifests/workload-metrics-hpa.yaml
@@ -15,7 +15,7 @@
 
 # [START gke_manifests_workload_metrics_hpa_horizontalpodautoscaler_workload_metrics_hpa]
 # [START container_workload_metrics_horizontal_pod_autoscaler_workload_metrics_hpa]
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: workload-metrics-hpa


### PR DESCRIPTION
## Description

<!-- Before creating this PR, make sure to thoroughly follow the contributing guide. -->
<!-- Add a description of the PR changes in this section. -->

This PR fixes `autoscaling/v2beta2` doesn't exist issue.

Followed https://cloud.google.com/kubernetes-engine/docs/tutorials/autoscaling-metrics and found this issue.

## Tasks

<!-- Once the PR has been created, check boxes as appropriate. -->

* [ ] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [x] The samples added / modified have been fully tested.
* [ ] Workflow files have been added / modified, if applicable.
* [ ] Region tags have been properly added, if new samples.
* [ ] All dependencies are set to up-to-date versions, as applicable.
