### PR TITLE
Set clearer PodMonitoring resource name.

### DIFF
--- a/observability/custom-metrics-autoscaling/google-managed-prometheus/custom-metrics-gmp.yaml
+++ b/observability/custom-metrics-autoscaling/google-managed-prometheus/custom-metrics-gmp.yaml
@@ -47,7 +47,7 @@ spec:
 apiVersion: monitoring.googleapis.com/v1
 kind: PodMonitoring
 metadata:
-  name: "prometheus-to-prometheus"
+  name: "custom-metrics-exporter"
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
Update the name of the `PodMonitoring` to better describe its purpose.

## Description

This CL updates the `PodMonitoring` resource name to better describe its relationship to Google Managed Prometheus.

## Tasks

<!-- Once the PR has been created, check boxes as appropriate. -->

* [ ] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [x] The samples added / modified have been fully tested.
* [x] Workflow files have been added / modified, if applicable.
* [x] Region tags have been properly added, if new samples.
* [x] All dependencies are set to up-to-date versions, as applicable.
