### PR TITLE
Fix typo in Gemma 1.1 7B serving with vLLM

### DIFF
--- a/ai-ml/llm-serving-gemma/vllm/vllm-1_1-7b.yaml
+++ b/ai-ml/llm-serving-gemma/vllm/vllm-1_1-7b.yaml
@@ -44,6 +44,7 @@ spec:
             memory: "25Gi"
             ephemeral-storage: "25Gi"
             nvidia.com/gpu: 2
+        command: ["python3", "-m", "vllm.entrypoints.api_server"]
         args:
         - --model=$(MODEL_ID)
         - --tensor-parallel-size=2


### PR DESCRIPTION


## Description

This PR fixes the typo in the YAML file for serving Gemma 1.1 7B model which is missing the command line argument (reported by the customer).

## Tasks

<!-- Once the PR has been created, check boxes as appropriate. -->

* [x] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [x] The samples added / modified have been fully tested.
* [ ] Workflow files have been added / modified, if applicable.
* [ ] Region tags have been properly added, if new samples.
* [ ] All dependencies are set to up-to-date versions, as applicable.
