### PR TITLE
add node selectors for Ray Stable Diffusion sample

### DIFF
--- a/ai-ml/gke-ray/rayserve/stable-diffusion/ray-cluster.yaml
+++ b/ai-ml/gke-ray/rayserve/stable-diffusion/ray-cluster.yaml
@@ -64,4 +64,6 @@ spec:
               cpu: 3
               memory: "16Gi"
               nvidia.com/gpu: 1
+        nodeSelector:
+          cloud.google.com/gke-accelerator: nvidia-l4
 # [END gke_ai_ml_gke_ray_rayserve_stable_diffusion_raycluster]

--- a/ai-ml/gke-ray/rayserve/stable-diffusion/ray-service.yaml
+++ b/ai-ml/gke-ray/rayserve/stable-diffusion/ray-service.yaml
@@ -71,4 +71,6 @@ spec:
                 cpu: 3
                 memory: "16Gi"
                 nvidia.com/gpu: 1
+          nodeSelector:
+            cloud.google.com/gke-accelerator: nvidia-l4
 # [END gke_ai_ml_gke_ray_rayserve_stable_diffusion_rayservice]


### PR DESCRIPTION
## Description

This PR adds a node selector for L4 GPU nodes to the Ray Stable Diffusion example. This way the sample works on both GKE Standard and Autopilot (requires node selectors for GPU pods)

## Tasks

<!-- Once the PR has been created, check boxes as appropriate. -->

* [x] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [x] The samples added / modified have been fully tested.
* [x] Workflow files have been added / modified, if applicable.
* [x] Region tags have been properly added, if new samples.
* [x] All dependencies are set to up-to-date versions, as applicable.
