### PR TITLE
Add PR template checkbox about merging once approved

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,3 +14,4 @@ This PR....
 * [ ] Workflow files have been added / modified, if applicable.
 * [ ] Region tags have been properly added, if new samples.
 * [ ] All dependencies are set to up-to-date versions, as applicable.
+* [ ] Merge this pull-request for me once it is approved.


### PR DESCRIPTION
## Description

* When a pull-request is created, it's not obvious whether the author would like the reviewer (e.g., me) to merge the pull-request immediately after I approve. Even if the pull-request is not in draft mode, the author of the pull-request may not want the pull-request to be merged immediately (e.g., if the merging needs to be coordinated with a cloud.google.com documentation change).
* See [this example pull-request](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/pull/1413#pullrequestreview-2242862932) where I asked the author if I should merge the pull-request immediately. 
    * I want to respect authors' time and ask this question proactively. 
* So I'm adding a `Merge this once approved` checklist item to the pull-request template's checklist.
* This is similar to what we have in the nodejs-docs-samples repo (see [pull-request from nodejs-docs-samples](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/pull/3791)).

## Tasks

* [x] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [x] The samples added / modified have been fully tested.
* [x] Workflow files have been added / modified, if applicable.
* [x] Region tags have been properly added, if new samples.
* [x] All dependencies are set to up-to-date versions, as applicable.
* [x] Merge this pull-request for me once it is approved.