### PR TITLE
Update TPU RayService to use Ray ML Image

### DIFF
--- a/ai-ml/gke-ray/rayserve/stable-diffusion/ray-service-tpu.yaml
+++ b/ai-ml/gke-ray/rayserve/stable-diffusion/ray-service-tpu.yaml
@@ -25,31 +25,20 @@ spec:
         runtime_env:
           working_dir: "https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/archive/refs/heads/main.zip"
           pip:
-            - pydantic<2
-            - google-api-python-client
-            - pillow
             - diffusers==0.7.2
-            - transformers==4.24.0
             - flax
-            - ml_dtypes==0.2.0
             - jax[tpu]==0.4.11
             - -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
             - fastapi
   rayClusterConfig:
-    rayVersion: '2.9.0' # Should match the Ray version in the image of the containers
-    ######################headGroupSpecs#################################
-    # Ray head pod template.
+    rayVersion: '2.9.0'
     headGroupSpec:
-      # The `rayStartParams` are used to configure the `ray start` command.
-      # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
-      # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
       rayStartParams: {}
-      # Pod template
       template:
         spec:
           containers:
           - name: ray-head
-            image: rayproject/ray:2.9.0-py310
+            image: rayproject/ray-ml:2.9.0-py310
             ports:
             - containerPort: 6379
               name: gcs
@@ -67,19 +56,17 @@ spec:
                 cpu: "2"
                 memory: "8G"
     workerGroupSpecs:
-    # The pod replicas in this group typed worker
     - replicas: 1
       minReplicas: 1
       maxReplicas: 10
       numOfHosts: 1
       groupName: tpu-group
       rayStartParams: {}
-      # Pod template
       template:
         spec:
           containers:
           - name: ray-worker
-            image: rayproject/ray:2.9.0-py310
+            image: rayproject/ray-ml:2.9.0-py310
             resources:
               limits:
                 # ct4p-hightpu-4t (v4) TPUs have 240 vCPUs, adjust this value based on your resource needs


### PR DESCRIPTION
## Description

<!-- Before creating this PR, make sure to thoroughly follow the contributing guide. -->
<!-- Add a description of the PR changes in this section. -->

This PR updates the RayService using TPUs to use the ray-ml 2.9 image rather than the regular Ray image. This allows us to remove several packages from the runtime environment install of the Ray Service (since they are already included in the image), freeing up ephemeral storage space to avoid hitting the 10 Gi limit on Autopilot. This PR has been manually tested on GKE Standard and Autopilot by deploying the RayService, verifying successful deployment, and sending numerous inference requests to the server.

## Tasks

<!-- Once the PR has been created, check boxes as appropriate. -->

* [x] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [x] The samples added / modified have been fully tested.
* [x] Workflow files have been added / modified, if applicable.
* [x] Region tags have been properly added, if new samples.
* [x] All dependencies are set to up-to-date versions, as applicable.
* [x] Merge this pull-request for me once it is approved.
