### PR TITLE
docs: Remove incorrect paragraphs

### DIFF
--- a/observability/elastic-stack-tutorial/elasticsearch.yaml
+++ b/observability/elastic-stack-tutorial/elasticsearch.yaml
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This file and other cloudbuild.yaml files are used to ensure that
-# our public Docker images such as gcr.io/google-samples/hello-app:1.0
-# are rebuilt and updated upon changes to the repository.
-
 # [START gke_monitoring_elastic_stack_elasticsearch]
 apiVersion: elasticsearch.k8s.elastic.co/v1
 kind: Elasticsearch

--- a/observability/elastic-stack-tutorial/fleet-server-and-agents.yaml
+++ b/observability/elastic-stack-tutorial/fleet-server-and-agents.yaml
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This file and other cloudbuild.yaml files are used to ensure that
-# our public Docker images such as gcr.io/google-samples/hello-app:1.0
-# are rebuilt and updated upon changes to the repository.
-
 # [START gke_monitoring_elastic_stack_fleet_agent]
 apiVersion: agent.k8s.elastic.co/v1alpha1
 kind: Agent

--- a/observability/elastic-stack-tutorial/ingress.yaml
+++ b/observability/elastic-stack-tutorial/ingress.yaml
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This file and other cloudbuild.yaml files are used to ensure that
-# our public Docker images such as gcr.io/google-samples/hello-app:1.0
-# are rebuilt and updated upon changes to the repository.
-
 # [START gke_monitoring_elastic_stack_frontend_config]
 apiVersion: networking.gke.io/v1beta1
 kind: FrontendConfig

--- a/observability/elastic-stack-tutorial/kibana.yaml
+++ b/observability/elastic-stack-tutorial/kibana.yaml
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This file and other cloudbuild.yaml files are used to ensure that
-# our public Docker images such as gcr.io/google-samples/hello-app:1.0
-# are rebuilt and updated upon changes to the repository.
-
 # [START gke_monitoring_elastic_stack_kibana]
 apiVersion: kibana.k8s.elastic.co/v1
 kind: Kibana

--- a/observability/elastic-stack-tutorial/max-map-count-setter-ds.yaml
+++ b/observability/elastic-stack-tutorial/max-map-count-setter-ds.yaml
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This file and other cloudbuild.yaml files are used to ensure that
-# our public Docker images such as gcr.io/google-samples/hello-app:1.0
-# are rebuilt and updated upon changes to the repository.
-
 # [START gke_monitoring_elastic_stack_daemon_set_priority_class]
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass

--- a/security/language-vulns/maven/src/main/java/com/example/helloworld/HelloworldApplication.java
+++ b/security/language-vulns/maven/src/main/java/com/example/helloworld/HelloworldApplication.java
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This file and other cloudbuild.yaml files are used to ensure that
-// our public Docker images such as gcr.io/google-samples/hello-app:1.0
-// are rebuilt and updated upon changes to the repository.
 package com.example.helloworld;
 
 import org.springframework.beans.factory.annotation.Value;


### PR DESCRIPTION
**Background:** 
* This repo has a bunch of cloudbuild.yaml files. See [search results for cloudbuild.yaml](https://github.com/search?q=repo%3AGoogleCloudPlatform%2Fkubernetes-engine-samples%20cloudbuild.yaml&type=code).
* These cloudbuild.yaml files configure Google Cloud Build to build and push Docker container images, so they all have comments similar to:
```
# This file and other cloudbuild.yaml files are used to ensure that
# our public Docker images such as us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.2
# are rebuilt and updated upon changes to the repository.
```

**Problem:**
* Those comments have been accidentally copied over to other non-cloudbuild.yaml files (I assume when the Apache 2.0 license headers were being copied).

**Changes in this pull-request:**
* In this pull-request, I'm remove these comments from files that shouldn't contain them.