### PR TITLE
upgrade ray version for ray server and ray train examples

### DIFF
--- a/ai-ml/gke-ray/rayserve/stable-diffusion/ray-cluster.yaml
+++ b/ai-ml/gke-ray/rayserve/stable-diffusion/ray-cluster.yaml
@@ -18,7 +18,7 @@ kind: RayCluster
 metadata:
   name: stable-diffusion-cluster
 spec:
-  rayVersion: '2.9.0'
+  rayVersion: '2.36.1'
   headGroupSpec:
     rayStartParams:
       dashboard-host: '0.0.0.0'
@@ -27,7 +27,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray-ml:2.9.0
+          image: rayproject/ray-ml:2.36.1
           ports:
           - containerPort: 6379
             name: gcs
@@ -54,7 +54,7 @@ spec:
       spec:
         containers:
         - name: ray-worker
-          image: rayproject/ray-ml:2.9.0
+          image: rayproject/ray-ml:2.36.1
           resources:
             limits:
               cpu: 4

--- a/ai-ml/gke-ray/rayserve/stable-diffusion/ray-service-tpu.yaml
+++ b/ai-ml/gke-ray/rayserve/stable-diffusion/ray-service-tpu.yaml
@@ -31,14 +31,14 @@ spec:
             - -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
             - fastapi
   rayClusterConfig:
-    rayVersion: '2.9.0'
+    rayVersion: '2.36.1'
     headGroupSpec:
       rayStartParams: {}
       template:
         spec:
           containers:
           - name: ray-head
-            image: rayproject/ray-ml:2.9.0-py310
+            image: rayproject/ray-ml:2.36.1
             ports:
             - containerPort: 6379
               name: gcs
@@ -66,7 +66,7 @@ spec:
         spec:
           containers:
           - name: ray-worker
-            image: rayproject/ray-ml:2.9.0-py310
+            image: rayproject/ray-ml:2.36.1
             resources:
               limits:
                 cpu: "100"

--- a/ai-ml/gke-ray/rayserve/stable-diffusion/ray-service.yaml
+++ b/ai-ml/gke-ray/rayserve/stable-diffusion/ray-service.yaml
@@ -26,7 +26,7 @@ spec:
           working_dir: "https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/archive/main.zip"
           pip: ["diffusers==0.12.1"]
   rayClusterConfig:
-    rayVersion: '2.9.0'
+    rayVersion: '2.36.1'
     headGroupSpec:
       rayStartParams:
         dashboard-host: '0.0.0.0'
@@ -34,7 +34,7 @@ spec:
         spec:
           containers:
           - name: ray-head
-            image: rayproject/ray-ml:2.9.0
+            image: rayproject/ray-ml:2.36.1
             ports:
             - containerPort: 6379
               name: gcs
@@ -61,7 +61,7 @@ spec:
         spec:
           containers:
           - name: ray-worker
-            image: rayproject/ray-ml:2.9.0
+            image: rayproject/ray-ml:2.36.1
             resources:
               limits:
                 cpu: 4

--- a/ai-ml/gke-ray/raytrain/pytorch-mnist/ray-cluster.yaml
+++ b/ai-ml/gke-ray/raytrain/pytorch-mnist/ray-cluster.yaml
@@ -18,7 +18,7 @@ kind: RayCluster
 metadata:
   name: pytorch-mnist-cluster
 spec:
-  rayVersion: '2.9.0'
+  rayVersion: '2.36.1'
   headGroupSpec:
     rayStartParams:
       dashboard-host: '0.0.0.0'
@@ -27,7 +27,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.9.0
+          image: rayproject/ray:2.36.1
           ports:
           - containerPort: 6379
             name: gcs
@@ -52,7 +52,7 @@ spec:
       spec:
         containers:
         - name: ray-worker
-          image: rayproject/ray:2.9.0
+          image: rayproject/ray:2.36.1
           resources:
             limits:
               cpu: 2

--- a/ai-ml/gke-ray/raytrain/pytorch-mnist/ray-job.yaml
+++ b/ai-ml/gke-ray/raytrain/pytorch-mnist/ray-job.yaml
@@ -29,14 +29,14 @@ spec:
       NUM_WORKERS: "4"
       CPUS_PER_WORKER: "2"
   rayClusterSpec:
-    rayVersion: '2.9.0'
+    rayVersion: '2.36.1'
     headGroupSpec:
       rayStartParams: {}
       template:
         spec:
           containers:
             - name: ray-head
-              image: rayproject/ray:2.9.0
+              image: rayproject/ray:2.36.1
               ports:
                 - containerPort: 6379
                   name: gcs-server
@@ -61,7 +61,7 @@ spec:
           spec:
             containers:
               - name: ray-worker
-                image: rayproject/ray:2.9.0
+                image: rayproject/ray:2.36.1
                 resources:
                   limits:
                     cpu: "2"


### PR DESCRIPTION
The current Ray version used in Ray train and Ray serve example is 2.9.0, which is staled. Updating to 2.36.1
