### PR TITLE
fix: Re-enable Renovate on Dockerfiles

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,9 +4,6 @@
     ":approveMajorUpdates",
     "schedule:earlyMondays",
   ],
-  "dockerfile": {
-    "enabled": false
-  },
   "pip-compile": {
     "enabled": true,
     "fileMatch": ["(^|/)requirements\\.in$"],


### PR DESCRIPTION
Background:
* This repo uses Renovate (Bot) to auto-create pull-requests that bump dependency versions (see [example Renovate pull-request](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/pull/1461)).
* In [2021 (pull-request 257)](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/pull/257), we disabled Renovate inside Dockerfile updates because, at the time, we didn't have automated tests that tested building of the new Dockerfiles. A pull-request reviewer (human) would have had to manually test `docker build`, locally.
* However, our GitHub Actions now test `docker build` when a change to a Dockerfile is made (see [pull-request 370](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/pull/370)).

Problem:
* Over the years, the images have been accumulating known vulnerabilities.
* See [Google-internal bugs](http://go/google-samples-images-bugs-2024).

Solution:
* This change renables Renovate on Dockerfiles.
* After merging, we should expect to see Renovate create [pull-request similar to this](https://github.com/GoogleCloudPlatform/microservices-demo/pull/2739/files).

* [x] Merge this pull-request for me once it is approved.
