### PR TITLE
Bump whereami base image to 3.13.0, bump Emoji version, disable debug…

### DIFF
--- a/quickstarts/whereami/Dockerfile
+++ b/quickstarts/whereami/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.7-slim
+FROM python:3.13.0-slim
 
 #MAINTAINER Alex Mattson "alex.mattson@gmail.com"
 

--- a/quickstarts/whereami/README.md
+++ b/quickstarts/whereami/README.md
@@ -19,7 +19,7 @@ Prometheus metrics are exposed from `whereami` at `x.x.x.x/metrics` in both Flas
 `whereami` is a single-container app, designed and packaged to run on Kubernetes. In its simplest form it can be deployed in a single line with only a few parameters.
 
 ```bash
-$ kubectl run --image=us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.22 --expose --port 8080 whereami
+$ kubectl run --image=us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.23 --expose --port 8080 whereami
 ```
 
 The `whereami`  pod listens on port `8080` and returns a very simple JSON response that indicates who is responding and where they live. This example assumes you're executing the `curl` command from a pod in the same K8s cluster & namespace (although the following examples show how to access from external clients):
@@ -99,7 +99,7 @@ spec:
       serviceAccountName: whereami
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.22
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.23
         resources:
           requests:
             memory: "512Mi"
@@ -559,7 +559,7 @@ If you'd like to deploy `whereami` via its Helm chart, you could leverage the fo
 Deploy the default setup of `whereami` (HTTP frontend):
 ```sh
 helm install whereami oci://us-docker.pkg.dev/google-samples/charts/whereami \
-    --version 1.2.22
+    --version 1.2.23
 ```
 
 Deploy `whereami` as HTTP backend by running the previous `helm install` command with the following parameters:

--- a/quickstarts/whereami/app.py
+++ b/quickstarts/whereami/app.py
@@ -206,5 +206,5 @@ if __name__ == '__main__':
         app.run(
             host=host_ip.strip('[]'), # stripping out the brackets if present
             port=int(os.environ.get('PORT', 8080)),
-            debug=True,
+            #debug=True,
             threaded=True)

--- a/quickstarts/whereami/cloudbuild.yaml
+++ b/quickstarts/whereami/cloudbuild.yaml
@@ -21,11 +21,11 @@ steps:
   args:
     - 'build'
     - '-t'
-    - 'gcr.io/google-samples/whereami:v1.2.22'
+    - 'gcr.io/google-samples/whereami:v1.2.23'
     - '-t'
-    - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.22'
+    - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.23'
     - '-t'
-    - 'europe-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.22'
+    - 'europe-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.23'
     - '.'
   dir: 'quickstarts/whereami'
 - name: ubuntu
@@ -35,9 +35,9 @@ steps:
     curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
     cd quickstarts/whereami/helm-chart
     helm package .
-    helm push whereami-1.2.22.tgz oci://us-docker.pkg.dev/google-samples/charts
+    helm push whereami-1.2.23.tgz oci://us-docker.pkg.dev/google-samples/charts
 
 images:
-  - 'gcr.io/google-samples/whereami:v1.2.22'
-  - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.22'
-  - 'europe-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.22'
+  - 'gcr.io/google-samples/whereami:v1.2.23'
+  - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.23'
+  - 'europe-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.23'

--- a/quickstarts/whereami/helm-chart/Chart.yaml
+++ b/quickstarts/whereami/helm-chart/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.22
+version: 1.2.23
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.2.22"
+appVersion: "v1.2.23"

--- a/quickstarts/whereami/k8s-grpc/deployment.yaml
+++ b/quickstarts/whereami/k8s-grpc/deployment.yaml
@@ -46,7 +46,7 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.22
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.23
         resources:
           requests:
             memory: "512Mi"
@@ -117,7 +117,7 @@ spec:
           - name: HOST
             valueFrom:
               configMapKeyRef:
-                name: whereami
+                name: whereami-grpc
                 key: HOST
 # [END gke_k8s_grpc_deployment_deployment_whereami_grpc]
 ---

--- a/quickstarts/whereami/k8s/deployment.yaml
+++ b/quickstarts/whereami/k8s/deployment.yaml
@@ -46,7 +46,7 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.22
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.23
         resources:
           requests:
             memory: "512Mi"

--- a/quickstarts/whereami/requirements.txt
+++ b/quickstarts/whereami/requirements.txt
@@ -1,6 +1,6 @@
 flask
 requests
-emoji==2.12.1
+emoji==2.14.0
 flask-cors
 grpcio
 grpcio-reflection


### PR DESCRIPTION
… mode for Flask, and fix configMap bug for gRPC

## Description

<!-- Before creating this PR, make sure to thoroughly follow the contributing guide. -->
<!-- Add a description of the PR changes in this section. -->

This PR updates Python base image and packages, fixes an issue with gRPC config map, and disables debug mode default. 

## Tasks

<!-- Once the PR has been created, check boxes as appropriate. -->

* [ x] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [ x] The samples added / modified have been fully tested.
* [ ] Workflow files have been added / modified, if applicable.
* [ ] Region tags have been properly added, if new samples.
* [ x] All dependencies are set to up-to-date versions, as applicable.
* [ x] Merge this pull-request for me once it is approved.
