### PR TITLE
Update references to Hugging Face DLC for TGI

### DIFF
--- a/ai-ml/llm-multiple-gpus/falcon-40b/text-generation-inference.yaml
+++ b/ai-ml/llm-multiple-gpus/falcon-40b/text-generation-inference.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: llm
-        image: ghcr.io/huggingface/text-generation-inference:1.4.3
+        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311
         resources:
           requests:
             cpu: "10"

--- a/ai-ml/llm-multiple-gpus/llama2-70b/text-generation-inference.yaml
+++ b/ai-ml/llm-multiple-gpus/llama2-70b/text-generation-inference.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: llm
-        image: ghcr.io/huggingface/text-generation-inference:1.4.3
+        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311
         resources:
           requests:
             cpu: "10"

--- a/ai-ml/llm-multiple-gpus/llama3-70b/text-generation-inference.yaml
+++ b/ai-ml/llm-multiple-gpus/llama3-70b/text-generation-inference.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: llm
-        image: ghcr.io/huggingface/text-generation-inference:2.0.4
+        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311
         resources:
           requests:
             cpu: "10"

--- a/ai-ml/llm-multiple-gpus/mixtral-8x7b/text-generation-inference.yaml
+++ b/ai-ml/llm-multiple-gpus/mixtral-8x7b/text-generation-inference.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: llm
-        image: ghcr.io/huggingface/text-generation-inference:1.4.3
+        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311
         resources:
           requests:
             cpu: "5"

--- a/ai-ml/llm-serving-gemma/tgi/tgi-1_1-2b-it.yaml
+++ b/ai-ml/llm-serving-gemma/tgi/tgi-1_1-2b-it.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
       - name: inference-server
-        image: ghcr.io/huggingface/text-generation-inference:2.0.2
+        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311
         resources:
           requests:
             cpu: "2"

--- a/ai-ml/llm-serving-gemma/tgi/tgi-1_1-7b-it.yaml
+++ b/ai-ml/llm-serving-gemma/tgi/tgi-1_1-7b-it.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
       - name: inference-server
-        image: ghcr.io/huggingface/text-generation-inference:2.0.2
+        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311
         resources:
           requests:
             cpu: "2"

--- a/ai-ml/llm-serving-gemma/tgi/tgi-2-27b-it.yaml
+++ b/ai-ml/llm-serving-gemma/tgi/tgi-2-27b-it.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
       - name: inference-server
-        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu121.2-1.ubuntu2204.py310
+        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311
         resources:
           requests:
             cpu: "10"

--- a/ai-ml/llm-serving-gemma/tgi/tgi-2-27b.yaml
+++ b/ai-ml/llm-serving-gemma/tgi/tgi-2-27b.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
       - name: inference-server
-        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu121.2-1.ubuntu2204.py310
+        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311
         resources:
           requests:
             cpu: "10"

--- a/ai-ml/llm-serving-gemma/tgi/tgi-2-2b-it.yaml
+++ b/ai-ml/llm-serving-gemma/tgi/tgi-2-2b-it.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
       - name: inference-server
-        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu121.2-1.ubuntu2204.py310
+        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311
         resources:
           requests:
             cpu: "2"

--- a/ai-ml/llm-serving-gemma/tgi/tgi-2-2b.yaml
+++ b/ai-ml/llm-serving-gemma/tgi/tgi-2-2b.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
       - name: inference-server
-        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu121.2-1.ubuntu2204.py310
+        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311
         resources:
           requests:
             cpu: "2"

--- a/ai-ml/llm-serving-gemma/tgi/tgi-2-9b-it.yaml
+++ b/ai-ml/llm-serving-gemma/tgi/tgi-2-9b-it.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
       - name: inference-server
-        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu121.2-1.ubuntu2204.py310
+        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311
         resources:
           requests:
             cpu: "4"

--- a/ai-ml/llm-serving-gemma/tgi/tgi-2-9b.yaml
+++ b/ai-ml/llm-serving-gemma/tgi/tgi-2-9b.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
       - name: inference-server
-        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu121.2-1.ubuntu2204.py310
+        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311
         resources:
           requests:
             cpu: "4"

--- a/ai-ml/llm-serving-gemma/tgi/tgi-2b-it-a100-40gb.yaml
+++ b/ai-ml/llm-serving-gemma/tgi/tgi-2b-it-a100-40gb.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: inference-server
-        image: ghcr.io/huggingface/text-generation-inference:2.0.2
+        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311
         resources:
           requests:
             ephemeral-storage: "20Gi"

--- a/ai-ml/llm-serving-gemma/tgi/tgi-2b-it-a100-80gb.yaml
+++ b/ai-ml/llm-serving-gemma/tgi/tgi-2b-it-a100-80gb.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: inference-server
-        image: ghcr.io/huggingface/text-generation-inference:2.0.2
+        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311
         resources:
           requests:
             ephemeral-storage: "20Gi"

--- a/ai-ml/llm-serving-gemma/tgi/tgi-2b-it-h100-80gb.yaml
+++ b/ai-ml/llm-serving-gemma/tgi/tgi-2b-it-h100-80gb.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: inference-server
-        image: ghcr.io/huggingface/text-generation-inference:2.0.2
+        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311
         resources:
           requests:
             ephemeral-storage: "20Gi"

--- a/ai-ml/llm-serving-gemma/tgi/tgi-2b-it.yaml
+++ b/ai-ml/llm-serving-gemma/tgi/tgi-2b-it.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
       - name: inference-server
-        image: ghcr.io/huggingface/text-generation-inference:2.0.2
+        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311
         resources:
           requests:
             cpu: "2"

--- a/ai-ml/llm-serving-gemma/tgi/tgi-2b.yaml
+++ b/ai-ml/llm-serving-gemma/tgi/tgi-2b.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
       - name: inference-server
-        image: ghcr.io/huggingface/text-generation-inference:2.0.2
+        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311
         resources:
           requests:
             cpu: "2"

--- a/ai-ml/llm-serving-gemma/tgi/tgi-7b-bitsandbytes-nf4.yaml
+++ b/ai-ml/llm-serving-gemma/tgi/tgi-7b-bitsandbytes-nf4.yaml
@@ -44,7 +44,7 @@ spec:
             secretKeyRef:
               key: hf_api_token
               name: hf-secret
-        image: ghcr.io/huggingface/text-generation-inference:2.0.2
+        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311
         name: inference-server
         resources:
           limits:

--- a/ai-ml/llm-serving-gemma/tgi/tgi-7b-bitsandbytes.yaml
+++ b/ai-ml/llm-serving-gemma/tgi/tgi-7b-bitsandbytes.yaml
@@ -44,7 +44,7 @@ spec:
             secretKeyRef:
               key: hf_api_token
               name: hf-secret
-        image: ghcr.io/huggingface/text-generation-inference:2.0.2
+        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311
         name: inference-server
         resources:
           limits:

--- a/ai-ml/llm-serving-gemma/tgi/tgi-7b-it-a100-40gb.yaml
+++ b/ai-ml/llm-serving-gemma/tgi/tgi-7b-it-a100-40gb.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: inference-server
-        image: ghcr.io/huggingface/text-generation-inference:2.0.2
+        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311
         resources:
           requests:
             ephemeral-storage: "40Gi"

--- a/ai-ml/llm-serving-gemma/tgi/tgi-7b-it-a100-80gb.yaml
+++ b/ai-ml/llm-serving-gemma/tgi/tgi-7b-it-a100-80gb.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: inference-server
-        image: ghcr.io/huggingface/text-generation-inference:2.0.2
+        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311
         resources:
           requests:
             ephemeral-storage: "40Gi"

--- a/ai-ml/llm-serving-gemma/tgi/tgi-7b-it-h100-80gb.yaml
+++ b/ai-ml/llm-serving-gemma/tgi/tgi-7b-it-h100-80gb.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: inference-server
-        image: ghcr.io/huggingface/text-generation-inference:2.0.2
+        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311
         resources:
           requests:
             ephemeral-storage: "40Gi"

--- a/ai-ml/llm-serving-gemma/tgi/tgi-7b-it-tensorparallelism.yaml
+++ b/ai-ml/llm-serving-gemma/tgi/tgi-7b-it-tensorparallelism.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: inference-server
-        image: ghcr.io/huggingface/text-generation-inference:2.0.2
+        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311
         resources:
           requests:
             cpu: "2"

--- a/ai-ml/llm-serving-gemma/tgi/tgi-7b-it.yaml
+++ b/ai-ml/llm-serving-gemma/tgi/tgi-7b-it.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
       - name: inference-server
-        image: ghcr.io/huggingface/text-generation-inference:2.0.2
+        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311
         resources:
           requests:
             cpu: "2"

--- a/ai-ml/llm-serving-gemma/tgi/tgi-7b-token.yaml
+++ b/ai-ml/llm-serving-gemma/tgi/tgi-7b-token.yaml
@@ -46,7 +46,7 @@ spec:
             secretKeyRef:
               key: hf_api_token
               name: hf-secret
-        image: ghcr.io/huggingface/text-generation-inference:2.0.2
+        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311
         name: inference-server
         resources:
           limits:

--- a/ai-ml/llm-serving-gemma/tgi/tgi-7b.yaml
+++ b/ai-ml/llm-serving-gemma/tgi/tgi-7b.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
       - name: inference-server
-        image: ghcr.io/huggingface/text-generation-inference:2.0.2
+        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311
         resources:
           requests:
             cpu: "2"

--- a/ai-ml/llm-serving-gemma/tgi/tgi-codegemma-1.1-2b.yaml
+++ b/ai-ml/llm-serving-gemma/tgi/tgi-codegemma-1.1-2b.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
       - name: inference-server
-        image: ghcr.io/huggingface/text-generation-inference:2.0.2
+        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311
         resources:
           requests:
             cpu: "2"

--- a/ai-ml/llm-serving-gemma/tgi/tgi-codegemma-1.1-7b-it.yaml
+++ b/ai-ml/llm-serving-gemma/tgi/tgi-codegemma-1.1-7b-it.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
       - name: inference-server
-        image: ghcr.io/huggingface/text-generation-inference:2.0.2
+        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311
         resources:
           requests:
             cpu: "2"


### PR DESCRIPTION
## Description

This PR updates some Kubernetes Deployment manifests so as to use the latest Hugging Face DLC for TGI (more information at https://cloud.google.com/deep-learning-containers/docs/choosing-container#hugging-face).

This PR updates:

- Some manifests were still pointing to ghcr.io/huggingface/text-generation-inference
- Some manifests were outdated and using older versions of TGI, whilst the latest is recommended, specially for improved Gemma2 support

As per discussed over email with @wietsevenema @moficodes 

## Tasks

* [x] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [ ] The samples added / modified have been fully tested.
* [ ] Workflow files have been added / modified, if applicable.
* [ ] Region tags have been properly added, if new samples.
* [x] All dependencies are set to up-to-date versions, as applicable.
* [x] Merge this pull-request for me once it is approved.