### PR TITLE
fix: Use python:3.13-alpine for metrics-exporter

### DIFF
--- a/cost-optimization/gke-vpa-recommendations/metrics-exporter/Dockerfile
+++ b/cost-optimization/gke-vpa-recommendations/metrics-exporter/Dockerfile
@@ -1,5 +1,4 @@
-
-FROM python:3.13 
+FROM python:3.13-alpine
 WORKDIR /app
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt


### PR DESCRIPTION
* This pull-request updates the [us-docker.pkg.dev/google-samples/containers/gke/metrics-exporter](https://us-docker.pkg.dev/google-samples/containers/gke/metrics-exporter) image to use the `python:3.13-alpine` image as a base image.
* `python...alpine` is one of the smallest `python...` images. See list of other `python...` images: https://hub.docker.com/_/python.
* Smaller the base image, the better —> fewer vulnerabilities, and faster build/push/pull time.
* According to [this article](https://medium.com/@arif.rahman.rhm/choosing-the-right-python-docker-image-slim-buster-vs-alpine-vs-slim-bullseye-5586bac8b4c9):
> Alpine takes the security crown with its minimal attack surface and frequent updates.
* See related Google-internal bug: b/378279820
* **How were these changes tested?** There is a GitHub check that `docker build`s the image. It's passing.
* This image is used in cloud.google.com tutorials: https://cloud.google.com/kubernetes-engine/docs/tutorials/right-size-workloads-at-scale#create_a_repository.
* The new [us-docker.pkg.dev/google-samples/containers/gke/metrics-exporter](https://us-docker.pkg.dev/google-samples/containers/gke/metrics-exporter) image will be rebuilt and repushed via Google Cloud Build triggers, when this pull-request is merged.