### PR TITLE
[FIX] Use the new entry point so the /metrics endpoint works.

### DIFF
--- a/ai-ml/llm-serving-gemma/vllm/vllm-2-27b-it.yaml
+++ b/ai-ml/llm-serving-gemma/vllm/vllm-2-27b-it.yaml
@@ -44,7 +44,7 @@ spec:
             memory: "80Gi"
             ephemeral-storage: "80Gi"
             nvidia.com/gpu: "4"
-        command: ["python3", "-m", "vllm.entrypoints.api_server"]
+        command: ["python3", "-m", "vllm.entrypoints.openai.api_server"]
         args:
         - --model=$(MODEL_ID)
         - --tensor-parallel-size=4

--- a/ai-ml/llm-serving-gemma/vllm/vllm-2-27b.yaml
+++ b/ai-ml/llm-serving-gemma/vllm/vllm-2-27b.yaml
@@ -44,7 +44,7 @@ spec:
             memory: "80Gi"
             ephemeral-storage: "120Gi"
             nvidia.com/gpu: "4"
-        command: ["python3", "-m", "vllm.entrypoints.api_server"]
+        command: ["python3", "-m", "vllm.entrypoints.openai.api_server"]
         args:
         - --model=$(MODEL_ID)
         - --tensor-parallel-size=4

--- a/ai-ml/llm-serving-gemma/vllm/vllm-2-2b-it.yaml
+++ b/ai-ml/llm-serving-gemma/vllm/vllm-2-2b-it.yaml
@@ -44,7 +44,7 @@ spec:
             memory: "10Gi"
             ephemeral-storage: "10Gi"
             nvidia.com/gpu: "1"
-        command: ["python3", "-m", "vllm.entrypoints.api_server"]
+        command: ["python3", "-m", "vllm.entrypoints.openai.api_server"]
         args:
         - --model=$(MODEL_ID)
         - --tensor-parallel-size=1

--- a/ai-ml/llm-serving-gemma/vllm/vllm-2-2b.yaml
+++ b/ai-ml/llm-serving-gemma/vllm/vllm-2-2b.yaml
@@ -44,7 +44,7 @@ spec:
             memory: "10Gi"
             ephemeral-storage: "12Gi"
             nvidia.com/gpu: "1"
-        command: ["python3", "-m", "vllm.entrypoints.api_server"]
+        command: ["python3", "-m", "vllm.entrypoints.openai.api_server"]
         args:
         - --model=$(MODEL_ID)
         - --tensor-parallel-size=1

--- a/ai-ml/llm-serving-gemma/vllm/vllm-2-9b-it.yaml
+++ b/ai-ml/llm-serving-gemma/vllm/vllm-2-9b-it.yaml
@@ -44,7 +44,7 @@ spec:
             memory: "30Gi"
             ephemeral-storage: "30Gi"
             nvidia.com/gpu: "2"
-        command: ["python3", "-m", "vllm.entrypoints.api_server"]
+        command: ["python3", "-m", "vllm.entrypoints.openai.api_server"]
         args:
         - --model=$(MODEL_ID)
         - --tensor-parallel-size=2

--- a/ai-ml/llm-serving-gemma/vllm/vllm-2-9b.yaml
+++ b/ai-ml/llm-serving-gemma/vllm/vllm-2-9b.yaml
@@ -44,7 +44,7 @@ spec:
             memory: "30Gi"
             ephemeral-storage: "45Gi"
             nvidia.com/gpu: "2"
-        command: ["python3", "-m", "vllm.entrypoints.api_server"]
+        command: ["python3", "-m", "vllm.entrypoints.openai.api_server"]
         args:
         - --model=$(MODEL_ID)
         - --tensor-parallel-size=2


### PR DESCRIPTION
## Description

<!-- Before creating this PR, make sure to thoroughly follow the contributing guide. -->
<!-- Add a description of the PR changes in this section. -->

This PR change the entrypoint command to use `vllm.entrypoints.openai.api_server`. The old one `vllm.entrypoints.api_server` doesn't expose the `/metrics` route.

Once it's merged, the example in the [doc](https://cloud.google.com/kubernetes-engine/docs/tutorials/serve-gemma-gpu-vllm#test-deployment) needs to be updated to the following:

```
USER_PROMPT="I'm new to coding. If you could only recommend one programming language to start with, what would it be and why?"

curl -X POST http://localhost:8000/v1/completions \
  -H "Content-Type: application/json" \
  -d @- <<EOF
{
    "model": "google/gemma-2-2b-it",
    "prompt": "<start_of_turn>user\n${USER_PROMPT}<end_of_turn>\n",
    "temperature": 0.90,
    "top_p": 1.0,
    "max_tokens": 128
}
EOF
```

The `gradio.yaml` file needs to be updated as well.

## Tasks

<!-- Once the PR has been created, check boxes as appropriate. -->

* [x] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [x] The samples added / modified have been fully tested.
* [ ] Workflow files have been added / modified, if applicable.
* [ ] Region tags have been properly added, if new samples.
* [ ] All dependencies are set to up-to-date versions, as applicable.
* [ ] Merge this pull-request for me once it is approved.
