### PR TITLE
Update Ray train samples

### DIFF
--- a/ai-ml/gke-ray/raytrain/pytorch-mnist/ray-cluster.yaml
+++ b/ai-ml/gke-ray/raytrain/pytorch-mnist/ray-cluster.yaml
@@ -18,7 +18,7 @@ kind: RayCluster
 metadata:
   name: pytorch-mnist-cluster
 spec:
-  rayVersion: '2.9.0'
+  rayVersion: '2.37.0'
   headGroupSpec:
     rayStartParams:
       dashboard-host: '0.0.0.0'
@@ -27,7 +27,7 @@ spec:
       spec:
         containers:
         - name: ray-head
-          image: rayproject/ray:2.9.0
+          image: rayproject/ray:2.37.0
           ports:
           - containerPort: 6379
             name: gcs
@@ -52,12 +52,12 @@ spec:
       spec:
         containers:
         - name: ray-worker
-          image: rayproject/ray:2.9.0
+          image: rayproject/ray:2.37.0
           resources:
             limits:
-              cpu: 2
+              cpu: 3
               memory: "8Gi"
             requests:
-              cpu: 2
+              cpu: 3
               memory: "8Gi"
 # [END gke_ai_ml_gke_ray_raytrain_pytorch_mnist_raycluster]

--- a/ai-ml/gke-ray/raytrain/pytorch-mnist/ray-cluster.yaml
+++ b/ai-ml/gke-ray/raytrain/pytorch-mnist/ray-cluster.yaml
@@ -38,9 +38,11 @@ spec:
           resources:
             limits:
               cpu: "2"
+              ephemeral-storage: "9Gi"
               memory: "4Gi"
             requests:
               cpu: "2"
+              ephemeral-storage: "9Gi"
               memory: "4Gi"
   workerGroupSpecs:
   - replicas: 4
@@ -56,8 +58,10 @@ spec:
           resources:
             limits:
               cpu: "4"
+              ephemeral-storage: "9Gi"
               memory: "8Gi"
             requests:
               cpu: "4"
+              ephemeral-storage: "9Gi"
               memory: "8Gi"
 # [END gke_ai_ml_gke_ray_raytrain_pytorch_mnist_raycluster]

--- a/ai-ml/gke-ray/raytrain/pytorch-mnist/ray-cluster.yaml
+++ b/ai-ml/gke-ray/raytrain/pytorch-mnist/ray-cluster.yaml
@@ -55,9 +55,9 @@ spec:
           image: rayproject/ray:2.37.0
           resources:
             limits:
-              cpu: 3
+              cpu: "4"
               memory: "8Gi"
             requests:
-              cpu: 3
+              cpu: "4"
               memory: "8Gi"
 # [END gke_ai_ml_gke_ray_raytrain_pytorch_mnist_raycluster]

--- a/ai-ml/gke-ray/raytrain/pytorch-mnist/ray-job.yaml
+++ b/ai-ml/gke-ray/raytrain/pytorch-mnist/ray-job.yaml
@@ -47,9 +47,11 @@ spec:
               resources:
                 limits:
                   cpu: "2"
+                  ephemeral-storage: "9Gi"
                   memory: "4Gi"
                 requests:
                   cpu: "2"
+                  ephemeral-storage: "9Gi"
                   memory: "4Gi"
     workerGroupSpecs:
       - replicas: 4
@@ -65,8 +67,10 @@ spec:
                 resources:
                   limits:
                     cpu: "4"
+                    ephemeral-storage: "9Gi"
                     memory: "8Gi"
                   requests:
                     cpu: "4"
+                    ephemeral-storage: "9Gi"
                     memory: "8Gi"
 # [END gke_ai_ml_gke_ray_raytrain_pytorch_mnist_rayjob]

--- a/ai-ml/gke-ray/raytrain/pytorch-mnist/ray-job.yaml
+++ b/ai-ml/gke-ray/raytrain/pytorch-mnist/ray-job.yaml
@@ -29,14 +29,14 @@ spec:
       NUM_WORKERS: "4"
       CPUS_PER_WORKER: "2"
   rayClusterSpec:
-    rayVersion: '2.9.0'
+    rayVersion: '2.37.0'
     headGroupSpec:
       rayStartParams: {}
       template:
         spec:
           containers:
             - name: ray-head
-              image: rayproject/ray:2.9.0
+              image: rayproject/ray:2.37.0
               ports:
                 - containerPort: 6379
                   name: gcs-server
@@ -61,12 +61,12 @@ spec:
           spec:
             containers:
               - name: ray-worker
-                image: rayproject/ray:2.9.0
+                image: rayproject/ray:2.37.0
                 resources:
                   limits:
-                    cpu: "2"
+                    cpu: "3"
                     memory: "8Gi"
                   requests:
-                    cpu: "2"
+                    cpu: "3"
                     memory: "8Gi"
 # [END gke_ai_ml_gke_ray_raytrain_pytorch_mnist_rayjob]

--- a/ai-ml/gke-ray/raytrain/pytorch-mnist/ray-job.yaml
+++ b/ai-ml/gke-ray/raytrain/pytorch-mnist/ray-job.yaml
@@ -64,9 +64,9 @@ spec:
                 image: rayproject/ray:2.37.0
                 resources:
                   limits:
-                    cpu: "3"
+                    cpu: "4"
                     memory: "8Gi"
                   requests:
-                    cpu: "3"
+                    cpu: "4"
                     memory: "8Gi"
 # [END gke_ai_ml_gke_ray_raytrain_pytorch_mnist_rayjob]


### PR DESCRIPTION
## Description

<!-- Before creating this PR, make sure to thoroughly follow the contributing guide. -->
<!-- Add a description of the PR changes in this section. -->

This PR updates the pytorch-mnist Ray samples to use a newer version of Ray and request more CPUs for the worker-group. These changes are necessary to keep the guide up-to date. Additionally, running through https://cloud.google.com/kubernetes-engine/docs/add-on/ray-on-gke/tutorials/train-model-ray-pytorch#standard results in the following error during job submission:
```
(autoscaler +2m59s) Error: No available node types can fulfill resource request {'CPU': 3.0}. Add suitable node types to this cluster to resolve this issue.
```
The `train.py` script specifies `CPUS_PER_WORKER": "2"`,  but the workers require 3 CPUs, not 2.
## Tasks

<!-- Once the PR has been created, check boxes as appropriate. -->

* [x] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [x] The samples added / modified have been fully tested.
* [x] Workflow files have been added / modified, if applicable.
* [ ] Region tags have been properly added, if new samples.
* [x] All dependencies are set to up-to-date versions, as applicable.
* [x] Merge this pull-request for me once it is approved.
