### PR TITLE
fix: Fix "helm push" of whereami major tag release

### DIFF
--- a/quickstarts/whereami/cloudbuild.yaml
+++ b/quickstarts/whereami/cloudbuild.yaml
@@ -46,8 +46,9 @@ steps:
     apt install curl -y
     curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
     cd quickstarts/whereami/helm-chart
-    helm package .
+    helm package . # This creates a file similar to whereami-X.Y.Z.tgz
     helm push whereami-1.2.23.tgz oci://us-docker.pkg.dev/google-samples/charts
+    cp whereami-1.2.23.tgz whereami-1.tgz
     helm push whereami-1.tgz oci://us-docker.pkg.dev/google-samples/charts
 
 images:


### PR DESCRIPTION
## Description

* For context, please see https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/pull/1540.
* This change fixes the following error encountered in the Cloud Build trigger that runs against commits on the main branch:
```
Error: whereami-1.tgz: no such file
```
* See [build logs here](https://console.cloud.google.com/cloud-build/builds/9b5ea98e-ba39-4879-a1cd-1accd376cadd).