### PR TITLE
Remove logic for pushing major-versioned whereami Helm chart

### DIFF
--- a/quickstarts/whereami/cloudbuild.yaml
+++ b/quickstarts/whereami/cloudbuild.yaml
@@ -49,7 +49,7 @@ steps:
     helm package . # This creates a file similar to whereami-X.Y.Z.tgz
     helm push whereami-1.2.23.tgz oci://us-docker.pkg.dev/google-samples/charts
     # Push Helm chart which could be referred to with just the major version tag
-    helm push oci://us-docker.pkg.dev/google-samples/charts/whereami --version 1
+    helm push us-docker.pkg.dev/google-samples/charts/whereami:1.2.23
 
 images:
   - 'gcr.io/google-samples/whereami:v1'

--- a/quickstarts/whereami/cloudbuild.yaml
+++ b/quickstarts/whereami/cloudbuild.yaml
@@ -49,7 +49,7 @@ steps:
     helm package . # This creates a file similar to whereami-X.Y.Z.tgz
     helm push whereami-1.2.23.tgz oci://us-docker.pkg.dev/google-samples/charts
     # Push Helm chart which could be referred to with just the major version tag
-    helm push us-docker.pkg.dev/google-samples/charts/whereami:1.2.23
+    helm push oci://us-docker.pkg.dev/google-samples/charts/whereami:1.2.23
 
 images:
   - 'gcr.io/google-samples/whereami:v1'

--- a/quickstarts/whereami/cloudbuild.yaml
+++ b/quickstarts/whereami/cloudbuild.yaml
@@ -48,8 +48,8 @@ steps:
     cd quickstarts/whereami/helm-chart
     helm package . # This creates a file similar to whereami-X.Y.Z.tgz
     helm push whereami-1.2.23.tgz oci://us-docker.pkg.dev/google-samples/charts
-    cp whereami-1.2.23.tgz whereami-1.tgz
-    helm push whereami-1.tgz oci://us-docker.pkg.dev/google-samples/charts
+    # Push Helm chart which could be referred to with just the major version tag
+    helm push oci://us-docker.pkg.dev/google-samples/charts/whereami --version 1
 
 images:
   - 'gcr.io/google-samples/whereami:v1'

--- a/quickstarts/whereami/cloudbuild.yaml
+++ b/quickstarts/whereami/cloudbuild.yaml
@@ -17,7 +17,29 @@
 # are rebuilt and updated upon changes to the repository.
 
 steps:
-# Temporarily removed for faster testing
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+    - 'build'
+    - '-t'
+    - 'gcr.io/google-samples/whereami:v1'
+    - '-t'
+    - 'gcr.io/google-samples/whereami:v1.2.23'
+    - '-t'
+    - 'gcr.io/google-samples/whereami:sample-public-image-v1.2.23-${SHORT_SHA}'
+    - '-t'
+    - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1'
+    - '-t'
+    - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.23'
+    - '-t'
+    - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:sample-public-image-v1.2.23-${SHORT_SHA}'
+    - '-t'
+    - 'europe-docker.pkg.dev/google-samples/containers/gke/whereami:v1'
+    - '-t'
+    - 'europe-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.23'
+    - '-t'
+    - 'europe-docker.pkg.dev/google-samples/containers/gke/whereami:sample-public-image-v1.2.23-${SHORT_SHA}'
+    - '.'
+  dir: 'quickstarts/whereami'
 - name: ubuntu
   script: |
     apt update
@@ -26,14 +48,6 @@ steps:
     cd quickstarts/whereami/helm-chart
     helm package . # This creates a file similar to whereami-X.Y.Z.tgz
     helm push whereami-1.2.23.tgz oci://us-docker.pkg.dev/google-samples/charts
-    
-    # Push Helm chart which allows users to refer to the chart by just the major tag (and pull the latest patch).
-    # Unfortunately, we cannot reuse the whereami-X.Y.Z.tgz file/package created above.
-    # We need to update the "version" and "appVersion" values in Chart.yaml and repackage.
-    sed -i "s/version: .*/version: 1/" Chart.yaml
-    sed -i "s/appVersion: .*/appVersion: \"1\"/" Chart.yaml
-    helm package . # This creates a file similar to whereami-X.tgz
-    helm push whereami-1.tgz oci://us-docker.pkg.dev/google-samples/charts/whereami
 
 images:
   - 'gcr.io/google-samples/whereami:v1'

--- a/quickstarts/whereami/cloudbuild.yaml
+++ b/quickstarts/whereami/cloudbuild.yaml
@@ -17,29 +17,7 @@
 # are rebuilt and updated upon changes to the repository.
 
 steps:
-- name: 'gcr.io/cloud-builders/docker'
-  args:
-    - 'build'
-    - '-t'
-    - 'gcr.io/google-samples/whereami:v1'
-    - '-t'
-    - 'gcr.io/google-samples/whereami:v1.2.23'
-    - '-t'
-    - 'gcr.io/google-samples/whereami:sample-public-image-v1.2.23-${SHORT_SHA}'
-    - '-t'
-    - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1'
-    - '-t'
-    - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.23'
-    - '-t'
-    - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:sample-public-image-v1.2.23-${SHORT_SHA}'
-    - '-t'
-    - 'europe-docker.pkg.dev/google-samples/containers/gke/whereami:v1'
-    - '-t'
-    - 'europe-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.23'
-    - '-t'
-    - 'europe-docker.pkg.dev/google-samples/containers/gke/whereami:sample-public-image-v1.2.23-${SHORT_SHA}'
-    - '.'
-  dir: 'quickstarts/whereami'
+# Temporarily removed for faster testing
 - name: ubuntu
   script: |
     apt update
@@ -52,8 +30,8 @@ steps:
     # Push Helm chart which allows users to refer to the chart by just the major tag (and pull the latest patch).
     # Unfortunately, we cannot reuse the whereami-X.Y.Z.tgz file/package created above.
     # We need to update the "version" and "appVersion" values in Chart.yaml and repackage.
-    sed -i "s/version: .*/version: $new_version/" Chart.yaml
-    sed -i "s/appVersion: .*/appVersion: \"$new_version\"/" Chart.yaml
+    sed -i "s/version: .*/version: 1/" Chart.yaml
+    sed -i "s/appVersion: .*/appVersion: \"1\"/" Chart.yaml
     helm package . # This creates a file similar to whereami-X.tgz
     helm push whereami-1.tgz oci://us-docker.pkg.dev/google-samples/charts/whereami
 

--- a/quickstarts/whereami/cloudbuild.yaml
+++ b/quickstarts/whereami/cloudbuild.yaml
@@ -48,8 +48,14 @@ steps:
     cd quickstarts/whereami/helm-chart
     helm package . # This creates a file similar to whereami-X.Y.Z.tgz
     helm push whereami-1.2.23.tgz oci://us-docker.pkg.dev/google-samples/charts
-    # Push Helm chart which could be referred to with just the major version tag
-    helm push oci://us-docker.pkg.dev/google-samples/charts/whereami:1.2.23
+    
+    # Push Helm chart which allows users to refer to the chart by just the major tag (and pull the latest patch).
+    # Unfortunately, we cannot reuse the whereami-X.Y.Z.tgz file/package created above.
+    # We need to update the "version" and "appVersion" values in Chart.yaml and repackage.
+    sed -i "s/version: .*/version: $new_version/" Chart.yaml
+    sed -i "s/appVersion: .*/appVersion: \"$new_version\"/" Chart.yaml
+    helm package . # This creates a file similar to whereami-X.tgz
+    helm push whereami-1.tgz oci://us-docker.pkg.dev/google-samples/charts/whereami
 
 images:
   - 'gcr.io/google-samples/whereami:v1'

--- a/quickstarts/whereami/cloudbuild.yaml
+++ b/quickstarts/whereami/cloudbuild.yaml
@@ -46,8 +46,9 @@ steps:
     apt install curl -y
     curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
     cd quickstarts/whereami/helm-chart
-    helm package .
+    helm package . # This creates a file similar to whereami-X.Y.Z.tgz
     helm push whereami-1.2.23.tgz oci://us-docker.pkg.dev/google-samples/charts
+    cp whereami-1.2.23.tgz whereami-1.tgz
     helm push whereami-1.tgz oci://us-docker.pkg.dev/google-samples/charts
 
 images:


### PR DESCRIPTION
**Background**

This pull-request is a follow up to:
1. https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/pull/1540 👈  This introduced the `v1` tag. But we saw errors in the building of the `v1` Helm chart.
2. https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/pull/1548 👈  This led to a new error. See [Cloud Build trigger logs here](https://cloud.console.google.com/cloud-build/builds/bb167225-6223-495e-b55e-79f220fbdf64).

In the first pull-request, we introduced a `v1` tag for the `whereami`, that lets users pull the latest `1.y.z` image. In other words, docs could reference `wheream:v1` instead of `wheream:v1.2.3` so that those docs don't need to be updated every time there's a new `whereami` patch or minor release.

**The issue**

Unfortunately, unlike Docker container images, the use of a `v1` tag doesn't work for Helm charts/packages images. Helm version tags must always contain the major, minor, _and_ patch number. See [Helm docs](https://helm.sh/docs/topics/charts/#charts-and-versioning):

> Every chart must have a version number. A version must follow the [SemVer 2](https://semver.org/spec/v2.0.0.html) standard.

The `helm install` command already takes care of this for us. See [`helm install` docs](https://helm.sh/docs/helm/helm_install/#options):

> `--version string` - specify a version constraint for the chart version to use. This constraint can be a specific tag (e.g. 1.1.1) or it may reference a valid range (e.g. ^2.0.0). If this is not specified, the latest version is used


**The solution**

This pull-request removes the logic that tries to build a Helm chart/package versioned with just the major tag (`v1`).