### PR TITLE
small update to vllm tpu yamls

### DIFF
--- a/ai-ml/vllm-tpu/vllm-hpa.yaml
+++ b/ai-ml/vllm-tpu/vllm-hpa.yaml
@@ -32,6 +32,6 @@ spec:
          name: prometheus.googleapis.com|vllm:num_requests_waiting|gauge
        target:
          type: AverageValue
-         averageValue: 1
+         averageValue: 10
 
 # [END gke_ai_ml_vllm_tpu_vllm_hpa]

--- a/ai-ml/vllm-tpu/vllm-llama3-70b.yaml
+++ b/ai-ml/vllm-tpu/vllm-llama3-70b.yaml
@@ -39,7 +39,7 @@ spec:
         cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
       containers:
       - name: vllm-tpu
-        image: REGION_NAME-docker.pkg.dev/PROJECT_ID/vllm-tpu/vllm-tpu:latest
+        image: IMAGE_NAME
         command: ["python3", "-m", "vllm.entrypoints.openai.api_server"]
         args:
         - --host=0.0.0.0


### PR DESCRIPTION
## Description

small updates:

1. change image to IMAGE_NAME to enable use of prebuilt images similar to guide here: https://cloud.google.com/kubernetes-engine/docs/tutorials/serve-multihost-gpu#deploy-vllm

2. change example HPA averageValue target to a more reasonable default setting (1 -> 10)

## Tasks

<!-- Once the PR has been created, check boxes as appropriate. -->

* [x] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [x] The samples added / modified have been fully tested.
* [x] Workflow files have been added / modified, if applicable.
* [x] Region tags have been properly added, if new samples.
* [x] Editable variables have been used, where applicable.
* [x] All dependencies are set to up-to-date versions, as applicable.
* [x] Merge this pull-request for me once it is approved.
