### PR TITLE
Inadvertent additional processed \n to carriage-return

### DIFF
--- a/ai-ml/llm-serving-gemma/tgi/gradio.yaml
+++ b/ai-ml/llm-serving-gemma/tgi/gradio.yaml
@@ -49,13 +49,9 @@ spec:
         - name: MODEL_ID
           value: "gemma"
         - name: USER_PROMPT
-          value: "<start_of_turn>user
-
-            prompt<end_of_turn>\n"
+          value: "<start_of_turn>user\nprompt<end_of_turn>\n"
         - name: SYSTEM_PROMPT
-          value: "<start_of_turn>model
-
-            prompt<end_of_turn>\n"
+          value: "<start_of_turn>model\nprompt<end_of_turn>\n"
         ports:
         - containerPort: 7860
 ---

--- a/ai-ml/llm-serving-gemma/vllm/gradio.yaml
+++ b/ai-ml/llm-serving-gemma/vllm/gradio.yaml
@@ -49,13 +49,9 @@ spec:
         - name: MODEL_ID
           value: "gemma"
         - name: USER_PROMPT
-          value: "<start_of_turn>user
-
-            prompt<end_of_turn>\n"
+          value: "<start_of_turn>user\nprompt<end_of_turn>\n"
         - name: SYSTEM_PROMPT
-          value: "<start_of_turn>model
-
-            prompt<end_of_turn>\n"
+          value: "<start_of_turn>model\nprompt<end_of_turn>\n"
         ports:
         - containerPort: 7860
 ---


### PR DESCRIPTION
## Description

<!-- Before creating this PR, make sure to thoroughly follow the contributing guide. -->
<!-- Add a description of the PR changes in this section. -->

This reverts some manifest values which interpreted a \n as a carriage return that is rendered.

## Tasks

<!-- Once the PR has been created, check boxes as appropriate. -->

* [x] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [x] The samples added / modified have been fully tested.
* [ ] Workflow files have been added / modified, if applicable.
* [ ] Region tags have been properly added, if new samples.
* [ ] Editable variables have been used, where applicable.
* [x] All dependencies are set to up-to-date versions, as applicable.
* [x] Merge this pull-request for me once it is approved.
