### PR TITLE
Remove compute class node selector from Ray Service head

### DIFF
--- a/ai-ml/gke-ray/rayserve/stable-diffusion/ray-service.yaml
+++ b/ai-ml/gke-ray/rayserve/stable-diffusion/ray-service.yaml
@@ -54,7 +54,6 @@ spec:
                 ephemeral-storage: "15Gi"
                 memory: "8Gi"
           nodeSelector:
-            cloud.google.com/compute-class: Performance
             cloud.google.com/machine-family: c3d
     workerGroupSpecs:
     - replicas: 1


### PR DESCRIPTION
## Description

<!-- Before creating this PR, make sure to thoroughly follow the contributing guide. -->
<!-- Add a description of the PR changes in this section. -->

This PR removes the compute class nodeSelector from the Stable Diffusion RayService manifest to match the RayCluster CR sample and enable compatibility with GKE Standard.

## Tasks

<!-- Once the PR has been created, check boxes as appropriate. -->

* [x] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [x] The samples added / modified have been fully tested.
* [ ] Workflow files have been added / modified, if applicable.
* [ ] Region tags have been properly added, if new samples.
* [ ] Editable variables have been used, where applicable.
* [ ] All dependencies are set to up-to-date versions, as applicable.
* [x] Merge this pull-request for me once it is approved.
