### PR TITLE
Fix `mountPath` to use `/tmp` instead of `/data`

### DIFF
--- a/ai-ml/llm-multiple-gpus/falcon-40b/text-generation-inference.yaml
+++ b/ai-ml/llm-multiple-gpus/falcon-40b/text-generation-inference.yaml
@@ -51,7 +51,7 @@ spec:
         volumeMounts:
           - mountPath: /dev/shm
             name: dshm
-          - mountPath: /data
+          - mountPath: /tmp
             name: ephemeral-volume
       volumes:
         - name: dshm

--- a/ai-ml/llm-multiple-gpus/llama2-70b/text-generation-inference.yaml
+++ b/ai-ml/llm-multiple-gpus/llama2-70b/text-generation-inference.yaml
@@ -56,7 +56,7 @@ spec:
         volumeMounts:
           - mountPath: /dev/shm
             name: dshm
-          - mountPath: /data
+          - mountPath: /tmp
             name: ephemeral-volume
       volumes:
         - name: dshm

--- a/ai-ml/llm-multiple-gpus/llama3-70b/text-generation-inference.yaml
+++ b/ai-ml/llm-multiple-gpus/llama3-70b/text-generation-inference.yaml
@@ -58,7 +58,7 @@ spec:
         volumeMounts:
           - mountPath: /dev/shm
             name: dshm
-          - mountPath: /data
+          - mountPath: /tmp
             name: ephemeral-volume
       volumes:
         - name: dshm

--- a/ai-ml/llm-multiple-gpus/mixtral-8x7b/text-generation-inference.yaml
+++ b/ai-ml/llm-multiple-gpus/mixtral-8x7b/text-generation-inference.yaml
@@ -56,7 +56,7 @@ spec:
         volumeMounts:
           - mountPath: /dev/shm
             name: dshm
-          - mountPath: /data
+          - mountPath: /tmp
             name: ephemeral-volume
       volumes:
         - name: dshm


### PR DESCRIPTION
## Description

This PR updates the `mountPath` so as to point to `/tmp` instead of `/data`, as the `HF_HOME` environment variable in the TGI DLCs is set to `/tmp` instead of the default `/data` set within the TGI default image (see [Dockerfile](https://github.com/huggingface/text-generation-inference/blob/23bc38b10d06f8cc271d086c26270976faf67cc2/Dockerfile#L184)); the change has always been there for the TGI DLC, but when setting the container URI i.e. the `image` within the Kubernetes manifests to the TGI DLC instead of the default TGI image (hosted on GitHub) as per https://github.com/GoogleCloudPlatform/ai-on-gke/pull/816, the `mountPath` were not updated, and it was still using `/data` which was leading to some issues when running the examples.

This has already been fixed within this repository in this PR, and also within https://github.com/GoogleCloudPlatform/ai-on-gke/pull/852.

cc @annapendleton @raushan2016

Closes #1581

## Tasks

* [X] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [ ] The samples added / modified have been fully tested.
* [ ] Workflow files have been added / modified, if applicable.
* [ ] Region tags have been properly added, if new samples.
* [ ] Editable variables have been used, where applicable.
* [ ] All dependencies are set to up-to-date versions, as applicable.
* [X] Merge this pull-request for me once it is approved.
