### PR TITLE
Add trigger to build KEDA cloud-pubsub docker image.

### DIFF
--- a/.github/terraform/google-cloud-build-triggers.tf
+++ b/.github/terraform/google-cloud-build-triggers.tf
@@ -252,6 +252,21 @@ resource "google_cloudbuild_trigger" "workload-metrics" {
     }
 }
 
+resource "google_cloudbuild_trigger" "keda-cloud-pubsub" {
+    name = "kubernetes-engine-samples-keda-cloud-pubsub"
+    filename = "cost-optimization/gke-keda/cloud-pubsub/cloudbuild.yaml"
+    included_files = ["cost-optimization/gke-keda/cloud-pubsub/**"]
+    description = local.trigger_description
+
+    github {
+        owner = "GoogleCloudPlatform"
+        name = "kubernetes-engine-samples"
+        push {
+            branch = "^main$"
+        }
+    }
+}
+
 resource "google_cloudbuild_trigger" "metrics-exporter" {
     name = "kubernetes-engine-samples-metrics-exporter"
     filename = "cost-optimization/gke-vpa-recommendations/metrics-exporter/cloudbuild.yaml"

--- a/.github/workflows/cost-optimization-gke-keda-ci.yml
+++ b/.github/workflows/cost-optimization-gke-keda-ci.yml
@@ -1,0 +1,21 @@
+name: cost-optimization-gke-keda-ci
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/cost-optimization-gke-keda-ci.yml'
+      - 'cost-optimization/gke-keda/cloud-pubsub/**'
+  pull_request:
+    paths:
+      - '.github/workflows/cost-optimization-gke-keda-ci.yml'
+      - 'cost-optimization/gke-keda/cloud-pubsub/**'
+jobs:
+  job:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: build gke-keda cloud-pubsub container
+        run: |
+          cd cost-optimization/gke-keda/cloud-pubsub
+          docker build --tag gke-keda-cloud-pubsub .


### PR DESCRIPTION
## Description

This PR adds a trigger to build the sample Docker image for the KEDA Cloud Pub/Sub sample.

## Tasks

<!-- Once the PR has been created, check boxes as appropriate. -->

* [ ] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [ ] The samples added / modified have been fully tested.
* [ ] Workflow files have been added / modified, if applicable.
* [ ] Region tags have been properly added, if new samples.
* [ ] Editable variables have been used, where applicable.
* [ ] All dependencies are set to up-to-date versions, as applicable.
* [ ] Merge this pull-request for me once it is approved.
