### PR TITLE
Reverting the TGI image version for LLAMA multiple GPUs in GKE samples

### DIFF
--- a/ai-ml/llm-multiple-gpus/falcon-40b/text-generation-inference.yaml
+++ b/ai-ml/llm-multiple-gpus/falcon-40b/text-generation-inference.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: llm
-        image: ghcr.io/huggingface/text-generation-inference:1.4.3
+        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu121.1-4.ubuntu2204.py310
         resources:
           requests:
             cpu: "10"

--- a/ai-ml/llm-multiple-gpus/falcon-40b/text-generation-inference.yaml
+++ b/ai-ml/llm-multiple-gpus/falcon-40b/text-generation-inference.yaml
@@ -51,7 +51,7 @@ spec:
         volumeMounts:
           - mountPath: /dev/shm
             name: dshm
-          # mountPath is set to /data as it's the path where the HF_HOME environment
+          # mountPath is set to /data as it's the path where the HUGGINGFACE_HUB_CACHE environment
           # variable points to in the TGI container image i.e. where the downloaded model from the Hub will be
           # stored
           - mountPath: /data

--- a/ai-ml/llm-multiple-gpus/falcon-40b/text-generation-inference.yaml
+++ b/ai-ml/llm-multiple-gpus/falcon-40b/text-generation-inference.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: llm
-        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311
+        image: ghcr.io/huggingface/text-generation-inference:1.4.3
         resources:
           requests:
             cpu: "10"
@@ -51,6 +51,9 @@ spec:
         volumeMounts:
           - mountPath: /dev/shm
             name: dshm
+          # mountPath is set to /data as it's the path where the HF_HOME environment
+          # variable points to in the TGI container image i.e. where the downloaded model from the Hub will be
+          # stored
           - mountPath: /data
             name: ephemeral-volume
       volumes:

--- a/ai-ml/llm-multiple-gpus/llama2-70b/text-generation-inference.yaml
+++ b/ai-ml/llm-multiple-gpus/llama2-70b/text-generation-inference.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: llm
-        image: ghcr.io/huggingface/text-generation-inference:1.4.3
+        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311
         resources:
           requests:
             cpu: "10"
@@ -56,10 +56,10 @@ spec:
         volumeMounts:
           - mountPath: /dev/shm
             name: dshm
-          # mountPath is set to /data as it's the path where the HF_HOME environment
-          # variable points to in the TGI container image i.e. where the downloaded model from the Hub will be
-          # stored
-          - mountPath: /data
+          # mountPath is set to /tmp as it's the path where the HF_HOME environment
+          # variable in the TGI DLCs is set to instead of the default /data set within the TGI default image.
+          # i.e. where the downloaded model from the Hub will be stored
+          - mountPath: /tmp
             name: ephemeral-volume
       volumes:
         - name: dshm

--- a/ai-ml/llm-multiple-gpus/llama2-70b/text-generation-inference.yaml
+++ b/ai-ml/llm-multiple-gpus/llama2-70b/text-generation-inference.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: llm
-        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311
+        image: ghcr.io/huggingface/text-generation-inference:1.4.3
         resources:
           requests:
             cpu: "10"
@@ -56,6 +56,9 @@ spec:
         volumeMounts:
           - mountPath: /dev/shm
             name: dshm
+          # mountPath is set to /data as it's the path where the HF_HOME environment
+          # variable points to in the TGI container image i.e. where the downloaded model from the Hub will be
+          # stored
           - mountPath: /data
             name: ephemeral-volume
       volumes:

--- a/ai-ml/llm-multiple-gpus/llama3-70b/text-generation-inference.yaml
+++ b/ai-ml/llm-multiple-gpus/llama3-70b/text-generation-inference.yaml
@@ -58,7 +58,7 @@ spec:
         volumeMounts:
           - mountPath: /dev/shm
             name: dshm
-          # mountPath is set to /tmp as it's the path where the HF_HOME environment
+          # mountPath is set to /tmp as it's the path where the HUGGINGFACE_HUB_CACHE environment
           # variable in the TGI DLCs is set to instead of the default /data set within the TGI default image.
           # i.e. where the downloaded model from the Hub will be stored
           - mountPath: /tmp

--- a/ai-ml/llm-multiple-gpus/llama3-70b/text-generation-inference.yaml
+++ b/ai-ml/llm-multiple-gpus/llama3-70b/text-generation-inference.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: llm
-        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311
+        image: ghcr.io/huggingface/text-generation-inference:2.0.4
         resources:
           requests:
             cpu: "10"
@@ -58,6 +58,9 @@ spec:
         volumeMounts:
           - mountPath: /dev/shm
             name: dshm
+          # mountPath is set to /data as it's the path where the HF_HOME environment
+          # variable points to in the TGI container image i.e. where the downloaded model from the Hub will be
+          # stored
           - mountPath: /data
             name: ephemeral-volume
       volumes:

--- a/ai-ml/llm-multiple-gpus/llama3-70b/text-generation-inference.yaml
+++ b/ai-ml/llm-multiple-gpus/llama3-70b/text-generation-inference.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: llm
-        image: ghcr.io/huggingface/text-generation-inference:2.0.4
+        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu121.2-1.ubuntu2204.py310
         resources:
           requests:
             cpu: "10"
@@ -58,10 +58,10 @@ spec:
         volumeMounts:
           - mountPath: /dev/shm
             name: dshm
-          # mountPath is set to /data as it's the path where the HF_HOME environment
-          # variable points to in the TGI container image i.e. where the downloaded model from the Hub will be
-          # stored
-          - mountPath: /data
+          # mountPath is set to /tmp as it's the path where the HF_HOME environment
+          # variable in the TGI DLCs is set to instead of the default /data set within the TGI default image.
+          # i.e. where the downloaded model from the Hub will be stored
+          - mountPath: /tmp
             name: ephemeral-volume
       volumes:
         - name: dshm

--- a/ai-ml/llm-multiple-gpus/mixtral-8x7b/text-generation-inference.yaml
+++ b/ai-ml/llm-multiple-gpus/mixtral-8x7b/text-generation-inference.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: llm
-        image: ghcr.io/huggingface/text-generation-inference:1.4.3
+        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311
         resources:
           requests:
             cpu: "5"
@@ -56,10 +56,10 @@ spec:
         volumeMounts:
           - mountPath: /dev/shm
             name: dshm
-          # mountPath is set to /data as it's the path where the HF_HOME environment
-          # variable points to in the TGI container image i.e. where the downloaded model from the Hub will be
-          # stored
-          - mountPath: /data
+          # mountPath is set to /tmp as it's the path where the HF_HOME environment
+          # variable in the TGI DLCs is set to instead of the default /data set within the TGI default image.
+          # i.e. where the downloaded model from the Hub will be stored
+          - mountPath: /tmp
             name: ephemeral-volume
       volumes:
         - name: dshm

--- a/ai-ml/llm-multiple-gpus/mixtral-8x7b/text-generation-inference.yaml
+++ b/ai-ml/llm-multiple-gpus/mixtral-8x7b/text-generation-inference.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: llm
-        image: us-docker.pkg.dev/deeplearning-platform-release/gcr.io/huggingface-text-generation-inference-cu124.2-3.ubuntu2204.py311
+        image: ghcr.io/huggingface/text-generation-inference:1.4.3
         resources:
           requests:
             cpu: "5"
@@ -56,6 +56,9 @@ spec:
         volumeMounts:
           - mountPath: /dev/shm
             name: dshm
+          # mountPath is set to /data as it's the path where the HF_HOME environment
+          # variable points to in the TGI container image i.e. where the downloaded model from the Hub will be
+          # stored
           - mountPath: /data
             name: ephemeral-volume
       volumes:


### PR DESCRIPTION

## Description

The current image override the HF_HOME to /tmp from /data. Even after changing the mountpath to /tmp there is some regression in the newer TGI image which results into out of GPU memory on L4 and requires atleast A2 node. Rolling back the image version to get the sample working will investigation happen in the background.

Issue: https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/issues/1581

## Tasks

<!-- Once the PR has been created, check boxes as appropriate. -->

* [x] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [x] The samples added / modified have been fully tested.
* [ ] Workflow files have been added / modified, if applicable.
* [ ] Region tags have been properly added, if new samples.
* [ ] Editable variables have been used, where applicable.
* [ ] All dependencies are set to up-to-date versions, as applicable.
* [x] Merge this pull-request for me once it is approved.
