### PR TITLE
whereami moved from commonlabels to labels

### DIFF
--- a/quickstarts/whereami/README.md
+++ b/quickstarts/whereami/README.md
@@ -268,8 +268,11 @@ It overlays the base manifest with the following Kustomization file:
 
 ```yaml
 nameSuffix: "-backend"
-commonLabels:
-  app: whereami-backend
+labels:
+- includeSelectors: true
+  includeTemplates: true
+  pairs:
+    app: whereami-backend
 resources:
 - ../k8s
 patches:

--- a/quickstarts/whereami/k8s-backend-overlay-example/kustomization.yaml
+++ b/quickstarts/whereami/k8s-backend-overlay-example/kustomization.yaml
@@ -1,6 +1,9 @@
 nameSuffix: "-backend"
-commonLabels:
-  app: whereami-backend
+labels:
+- includeSelectors: true
+  includeTemplates: true
+  pairs:
+    app: whereami-backend
 resources:
 - ../k8s
 patches:

--- a/quickstarts/whereami/k8s-echo-headers-overlay-example/kustomization.yaml
+++ b/quickstarts/whereami/k8s-echo-headers-overlay-example/kustomization.yaml
@@ -1,6 +1,9 @@
 nameSuffix: "-echo-headers"
-commonLabels:
-  app: whereami-echo-headers
+labels:
+- includeSelectors: true
+  includeTemplates: true
+  pairs:
+    app: whereami-echo-headers
 resources:
 - ../k8s
 patches:

--- a/quickstarts/whereami/k8s-frontend-overlay-example/kustomization.yaml
+++ b/quickstarts/whereami/k8s-frontend-overlay-example/kustomization.yaml
@@ -1,6 +1,9 @@
 nameSuffix: "-frontend"
-commonLabels:
-  app: whereami-frontend
+labels:
+- includeSelectors: true
+  includeTemplates: true
+  pairs:
+    app: whereami-frontend
 resources:
 - ../k8s
 patches:

--- a/quickstarts/whereami/k8s-grpc-backend-overlay-example/kustomization.yaml
+++ b/quickstarts/whereami/k8s-grpc-backend-overlay-example/kustomization.yaml
@@ -1,6 +1,9 @@
 nameSuffix: "-backend"
-commonLabels:
-  app: whereami-grpc-backend
+labels:
+- includeSelectors: true
+  includeTemplates: true
+  pairs:
+    app: whereami-grpc-backend
 resources:
 - ../k8s-grpc
 patches:

--- a/quickstarts/whereami/k8s-grpc-frontend-overlay-example/kustomization.yaml
+++ b/quickstarts/whereami/k8s-grpc-frontend-overlay-example/kustomization.yaml
@@ -1,6 +1,9 @@
 nameSuffix: "-frontend"
-commonLabels:
-  app: whereami-grpc-frontend
+labels:
+- includeSelectors: true
+  includeTemplates: true
+  pairs:
+    app: whereami-grpc-frontend
 resources:
 - ../k8s-grpc
 patches:


### PR DESCRIPTION
## Description

<!-- Before creating this PR, make sure to thoroughly follow the contributing guide. -->
<!-- Add a description of the PR changes in this section. -->

This PR modifies the whereami Kustomize overlay examples and moves from the deprecated `commonLabels` annotations to regular label pairs. Tested for both HTTP and gRPC traffic. 

## Tasks

<!-- Once the PR has been created, check boxes as appropriate. -->

* [ x] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [ x] The samples added / modified have been fully tested.
* [ x] Workflow files have been added / modified, if applicable.
* [ x] Region tags have been properly added, if new samples.
* [ x] Editable variables have been used, where applicable.
* [ x] All dependencies are set to up-to-date versions, as applicable.
* [ x] Merge this pull-request for me once it is approved.
