### PR TITLE
fixed missing patch for whereami commonlabels 

### DIFF
--- a/quickstarts/whereami/k8s-frontend-overlay-clusterip-example/kustomization.yaml
+++ b/quickstarts/whereami/k8s-frontend-overlay-clusterip-example/kustomization.yaml
@@ -1,6 +1,9 @@
 nameSuffix: "-frontend"
-commonLabels:
-  app: whereami-frontend
+labels:
+- includeSelectors: true
+  includeTemplates: true
+  pairs:
+    app: whereami-frontend
 resources:
 - ../k8s
 patches:


### PR DESCRIPTION
## Description

<!-- Before creating this PR, make sure to thoroughly follow the contributing guide. -->
<!-- Add a description of the PR changes in this section. -->

This PR fixes a missing element of https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/pull/1594 

I missed a subfolder `k8s-frontend-overlay-clusterip-example` so this fixes it 

## Tasks

<!-- Once the PR has been created, check boxes as appropriate. -->

* [ x] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [ x] The samples added / modified have been fully tested.
* [x ] Workflow files have been added / modified, if applicable.
* [ x] Region tags have been properly added, if new samples.
* [ x] Editable variables have been used, where applicable.
* [ x] All dependencies are set to up-to-date versions, as applicable.
* [ x] Merge this pull-request for me once it is approved.
