### PR TITLE
fix(gke): fix wrong placeholder tags in YAML

### DIFF
--- a/databases/stateful-workload-filestore/preprov-pv.yaml
+++ b/databases/stateful-workload-filestore/preprov-pv.yaml
@@ -30,8 +30,8 @@ spec:
   csi:
     driver: filestore.csi.storage.gke.io
     # Modify this to use the zone, filestore instance and share name.
-    volumeHandle: "modeInstance/<FILESTORE_ZONE>/<INSTANCE_NAME>/<FILESTORE_SHARE_NAME>"
+    volumeHandle: "modeInstance/<LOCATION>/<INSTANCE_NAME>/<FILE_SHARE_NAME>"
     volumeAttributes:
       ip: <IP_ADDRESS> # Modify this to Pre-provisioned Filestore instance IP
-      volume: <FILESTORE_SHARE_NAME> # Modify this to Pre-provisioned Filestore instance share name
+      volume: <FILE_SHARE_NAME> # Modify this to Pre-provisioned Filestore instance share name
 # [END gke_stateful_filestore_preprov_pv]


### PR DESCRIPTION
## Description

- Replace the wrong placeholder names as required in tutorial [Stateful workload with Filestore](https://cloud.google.com/kubernetes-engine/docs/tutorials/stateful-workload#configure_the_managed_file_storage_with_using_csi)

## Tasks

* [x] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [x] The samples added / modified have been fully tested.
* [ ] Workflow files have been added / modified, if applicable. -> N/A
* [ ] Region tags have been properly added, if new samples. -> N/A
* [x] Editable variables have been used, where applicable.
* [ ] All dependencies are set to up-to-date versions, as applicable. -> N/A
* [x] Merge this pull-request for me once it is approved.
