### PR TITLE
remove gcsfuse from jetstream pytorch setup to resolve race condition

### DIFF
--- a/ai-ml/llm-serving-tpus-jetstream/pytorch/jetstream-pytorch-gemma-7b-it-2x4.yaml
+++ b/ai-ml/llm-serving-tpus-jetstream/pytorch/jetstream-pytorch-gemma-7b-it-2x4.yaml
@@ -26,8 +26,6 @@ spec:
     metadata:
       labels:
         app: jetstream-pytorch-server
-      annotations:
-        gke-gcsfuse/volumes: "true"
     spec:
       nodeSelector:
         cloud.google.com/gke-tpu-topology: 2x4
@@ -38,11 +36,8 @@ spec:
         args:
         - --model_id=google/gemma-7b-it
         - --override_batch_size=30
-        - --working_dir=/models/pytorch/
         - --enable_model_warmup=True
         volumeMounts:
-        - name: gcs-fuse-checkpoint
-          mountPath: /models
         - name: huggingface-credentials
           mountPath: /huggingface
           readOnly: true
@@ -84,15 +79,6 @@ spec:
         secret:
           defaultMode: 0400
           secretName: huggingface-secret
-      - name: gke-gcsfuse-cache
-        emptyDir:
-          medium: Memory
-      - name: gcs-fuse-checkpoint
-        csi:
-          driver: gcsfuse.csi.storage.gke.io
-          volumeAttributes:
-            bucketName: BUCKET_NAME
-            mountOptions: "implicit-dirs,file-cache:enable-parallel-downloads:true,file-cache:parallel-downloads-per-file:100,file-cache:max-parallel-downloads:-1,file-cache:download-chunk-size-mb:10,file-cache:max-size-mb:-1"
 ---
 apiVersion: v1
 kind: Service

--- a/ai-ml/llm-serving-tpus-jetstream/pytorch/jetstream-pytorch-llama-3-8b-2x4.yaml
+++ b/ai-ml/llm-serving-tpus-jetstream/pytorch/jetstream-pytorch-llama-3-8b-2x4.yaml
@@ -26,8 +26,6 @@ spec:
     metadata:
       labels:
         app: jetstream-pytorch-server
-      annotations:
-        gke-gcsfuse/volumes: "true"
     spec:
       nodeSelector:
         cloud.google.com/gke-tpu-topology: 2x4
@@ -38,11 +36,8 @@ spec:
         args:
         - --model_id=meta-llama/Meta-Llama-3-8B
         - --override_batch_size=30
-        - --working_dir=/models/pytorch/
         - --enable_model_warmup=True
         volumeMounts:
-        - name: gcs-fuse-checkpoint
-          mountPath: /models
         - name: huggingface-credentials
           mountPath: /huggingface
           readOnly: true
@@ -84,15 +79,6 @@ spec:
         secret:
           defaultMode: 0400
           secretName: huggingface-secret
-      - name: gke-gcsfuse-cache
-        emptyDir:
-          medium: Memory
-      - name: gcs-fuse-checkpoint
-        csi:
-          driver: gcsfuse.csi.storage.gke.io
-          volumeAttributes:
-            bucketName: BUCKET_NAME
-            mountOptions: "implicit-dirs,file-cache:enable-parallel-downloads:true,file-cache:parallel-downloads-per-file:100,file-cache:max-parallel-downloads:-1,file-cache:download-chunk-size-mb:10,file-cache:max-size-mb:-1"
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Description

<!-- Before creating this PR, make sure to thoroughly follow the contributing guide. -->
<!-- Add a description of the PR changes in this section. -->

This PR removes GCSFuse integration for the JetStream PyTorch guide to resolve the race condition for 2+ replicas reading and writing from the same bucket and incomplete files.

## Tasks

<!-- Once the PR has been created, check boxes as appropriate. -->

* [x] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [x] The samples added / modified have been fully tested.
* [x] Workflow files have been added / modified, if applicable.
* [x] Region tags have been properly added, if new samples.
* [x] Editable variables have been used, where applicable.
* [x] All dependencies are set to up-to-date versions, as applicable.
* [x] Merge this pull-request for me once it is approved.
