### PR TITLE
added a readiness probe of 16 mins for llama 70b

### DIFF
--- a/ai-ml/vllm-tpu/vllm-llama3-70b.yaml
+++ b/ai-ml/vllm-tpu/vllm-llama3-70b.yaml
@@ -68,7 +68,7 @@ spec:
         readinessProbe:
           tcpSocket:
             port: 8000
-          initialDelaySeconds: 15
+          initialDelaySeconds: 900
           periodSeconds: 10
         volumeMounts:
         - name: gcs-fuse-csi-ephemeral


### PR DESCRIPTION
## Description

Added a longer readiness probe initial delay because llama 70b for this recipe takes ~15 minutes to startup 

* [x] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [x] The samples added / modified have been fully tested.
* [ ] Workflow files have been added / modified, if applicable.
* [ ] Region tags have been properly added, if new samples.
* [ ] Editable variables have been used, where applicable.
* [ ] All dependencies are set to up-to-date versions, as applicable.
* [ ] Merge this pull-request for me once it is approved.
