### PR TITLE
Lower ephemeral storage limit of RayCluster CR

### DIFF
--- a/ai-ml/gke-ray/rayserve/llm/tpu/ray-cluster.tpu-v5e-singlehost.yaml
+++ b/ai-ml/gke-ray/rayserve/llm/tpu/ray-cluster.tpu-v5e-singlehost.yaml
@@ -103,12 +103,12 @@ spec:
               limits:
                 cpu: "100"
                 google.com/tpu: "8"
-                ephemeral-storage: 80G
+                ephemeral-storage: 40G
                 memory: 200G
               requests:
                 cpu: "100"
                 google.com/tpu: "8"
-                ephemeral-storage: 80G
+                ephemeral-storage: 40G
                 memory: 200G
             env:
               - name: VLLM_XLA_CACHE_PATH


### PR DESCRIPTION
## Description

<!-- Before creating this PR, make sure to thoroughly follow the contributing guide. -->
<!-- Add a description of the PR changes in this section. -->

This PR updates the ephemeral storage limits/requests on a Ray v5e TPU worker to match the other CRs in this guide: https://cloud.google.com/kubernetes-engine/docs/tutorials/serve-lllm-tpu-ray. 

## Tasks

<!-- Once the PR has been created, check boxes as appropriate. -->

* [x] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [x] The samples added / modified have been fully tested.
* [x] Workflow files have been added / modified, if applicable.
* [x] Region tags have been properly added, if new samples.
* [x] Editable variables have been used, where applicable.
* [x] All dependencies are set to up-to-date versions, as applicable.
* [x] Merge this pull-request for me once it is approved.
