### PR TITLE
Add a basic deployment manifest for selecting a compute class 

### DIFF
--- a/quickstarts/hello-app/manifests/helloweb-computeclass-deployment.yaml
+++ b/quickstarts/hello-app/manifests/helloweb-computeclass-deployment.yaml
@@ -1,0 +1,45 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Basic hello-app deployment with a node selector for any compute class
+
+# [START gke_helloweb_computeclass_deployment]
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: helloweb
+  labels:
+    app: hello
+spec:
+  selector:
+    matchLabels:
+      app: hello
+  template:
+    metadata:
+      labels:
+        app: hello
+    spec:
+      nodeSelector:
+        # Replace with the name of a compute class
+        cloud.google.com/compute-class: COMPUTE_CLASS 
+      containers:
+      - name: hello-app
+        image: us-docker.pkg.dev/google-samples/containers/gke/hello-app:1.0
+        ports:
+        - containerPort: 8080
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "4Gi"
+# [END gke_helloweb_computeclass_deployment]


### PR DESCRIPTION
## Description

Add a manifest that selects a compute class using a placeholder variable. This manifest can be included in multiple documentation pages, single-sourcing the basic example of a compute class being used. 

## Tasks

<!-- Once the PR has been created, check boxes as appropriate. -->

* [x] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [x] The samples added / modified have been fully tested.
* [x] Workflow files have been added / modified, if applicable. (not applicable)
* [x] Region tags have been properly added, if new samples.
* [x] Editable variables have been used, where applicable.
* [x] All dependencies are set to up-to-date versions, as applicable.
* [x] Merge this pull-request for me once it is approved.
