### PR TITLE
bump whereami to base 1.13.5-slim image

### DIFF
--- a/quickstarts/whereami/Dockerfile
+++ b/quickstarts/whereami/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.4-slim
+FROM python:3.13.5-slim
 
 #MAINTAINER Alex Mattson "alex.mattson@gmail.com"
 

--- a/quickstarts/whereami/README.md
+++ b/quickstarts/whereami/README.md
@@ -19,7 +19,7 @@ Prometheus metrics are exposed from `whereami` at `x.x.x.x/metrics` in both Flas
 `whereami` is a single-container app, designed and packaged to run on Kubernetes. In its simplest form it can be deployed in a single line with only a few parameters.
 
 ```bash
-$ kubectl run --image=us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.24 --expose --port 8080 whereami
+$ kubectl run --image=us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.25 --expose --port 8080 whereami
 ```
 
 The `whereami`  pod listens on port `8080` and returns a very simple JSON response that indicates who is responding and where they live. This example assumes you're executing the `curl` command from a pod in the same K8s cluster & namespace (although the following examples show how to access from external clients):
@@ -99,7 +99,7 @@ spec:
       serviceAccountName: whereami
       containers:
       - name: whereami
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.24
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.25
         resources:
           requests:
             memory: "512Mi"
@@ -562,7 +562,7 @@ If you'd like to deploy `whereami` via its Helm chart, you could leverage the fo
 Deploy the default setup of `whereami` (HTTP frontend):
 ```sh
 helm install whereami oci://us-docker.pkg.dev/google-samples/charts/whereami \
-    --version 1.2.24
+    --version 1.2.25
 ```
 
 Deploy `whereami` as HTTP backend by running the previous `helm install` command with the following parameters:

--- a/quickstarts/whereami/cloudbuild.yaml
+++ b/quickstarts/whereami/cloudbuild.yaml
@@ -23,21 +23,21 @@ steps:
     - '-t'
     - 'gcr.io/google-samples/whereami:v1'
     - '-t'
-    - 'gcr.io/google-samples/whereami:v1.2.24'
+    - 'gcr.io/google-samples/whereami:v1.2.25'
     - '-t'
-    - 'gcr.io/google-samples/whereami:sample-public-image-v1.2.24-${SHORT_SHA}'
+    - 'gcr.io/google-samples/whereami:sample-public-image-v1.2.25-${SHORT_SHA}'
     - '-t'
     - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1'
     - '-t'
-    - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.24'
+    - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.25'
     - '-t'
-    - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:sample-public-image-v1.2.24-${SHORT_SHA}'
+    - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:sample-public-image-v1.2.25-${SHORT_SHA}'
     - '-t'
     - 'europe-docker.pkg.dev/google-samples/containers/gke/whereami:v1'
     - '-t'
-    - 'europe-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.24'
+    - 'europe-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.25'
     - '-t'
-    - 'europe-docker.pkg.dev/google-samples/containers/gke/whereami:sample-public-image-v1.2.24-${SHORT_SHA}'
+    - 'europe-docker.pkg.dev/google-samples/containers/gke/whereami:sample-public-image-v1.2.25-${SHORT_SHA}'
     - '.'
   dir: 'quickstarts/whereami'
 - name: ubuntu
@@ -47,15 +47,15 @@ steps:
     curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
     cd quickstarts/whereami/helm-chart
     helm package . # This creates a file similar to whereami-X.Y.Z.tgz
-    helm push whereami-1.2.24.tgz oci://us-docker.pkg.dev/google-samples/charts
+    helm push whereami-1.2.25.tgz oci://us-docker.pkg.dev/google-samples/charts
 
 images:
   - 'gcr.io/google-samples/whereami:v1'
-  - 'gcr.io/google-samples/whereami:v1.2.24'
-  - 'gcr.io/google-samples/whereami:sample-public-image-v1.2.24-${SHORT_SHA}'
+  - 'gcr.io/google-samples/whereami:v1.2.25'
+  - 'gcr.io/google-samples/whereami:sample-public-image-v1.2.25-${SHORT_SHA}'
   - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1'
-  - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.24'
-  - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:sample-public-image-v1.2.24-${SHORT_SHA}'
+  - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.25'
+  - 'us-docker.pkg.dev/google-samples/containers/gke/whereami:sample-public-image-v1.2.25-${SHORT_SHA}'
   - 'europe-docker.pkg.dev/google-samples/containers/gke/whereami:v1'
-  - 'europe-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.24'
-  - 'europe-docker.pkg.dev/google-samples/containers/gke/whereami:sample-public-image-v1.2.24-${SHORT_SHA}'
+  - 'europe-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.25'
+  - 'europe-docker.pkg.dev/google-samples/containers/gke/whereami:sample-public-image-v1.2.25-${SHORT_SHA}'

--- a/quickstarts/whereami/helm-chart/Chart.yaml
+++ b/quickstarts/whereami/helm-chart/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.24
+version: 1.2.25
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.2.24"
+appVersion: "v1.2.25"

--- a/quickstarts/whereami/k8s-grpc/deployment.yaml
+++ b/quickstarts/whereami/k8s-grpc/deployment.yaml
@@ -46,7 +46,7 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.24
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.25
         resources:
           requests:
             memory: "512Mi"

--- a/quickstarts/whereami/k8s/deployment.yaml
+++ b/quickstarts/whereami/k8s/deployment.yaml
@@ -46,7 +46,7 @@ spec:
               - all
           privileged: false
           readOnlyRootFilesystem: true
-        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.24
+        image: us-docker.pkg.dev/google-samples/containers/gke/whereami:v1.2.25
         resources:
           requests:
             memory: "512Mi"


### PR DESCRIPTION
## Description

<!-- Before creating this PR, make sure to thoroughly follow the contributing guide. -->
<!-- Add a description of the PR changes in this section. -->

This PR bumps the base image for whereami from 1.13.4 to 1.13.5, and updates the references to the new version in deployments, readme, and helm files.

## Tasks

<!-- Once the PR has been created, check boxes as appropriate. -->

* [x] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [x] The samples added / modified have been fully tested.
* [ ] Workflow files have been added / modified, if applicable.
* [ ] Region tags have been properly added, if new samples.
* [x] Editable variables have been used, where applicable.
* [x] All dependencies are set to up-to-date versions, as applicable.
* [x] Merge this pull-request for me once it is approved.
