### PR TITLE
Reduce memory request to avoid large machine types

### DIFF
--- a/quickstarts/hello-app/manifests/helloweb-computeclass-deployment.yaml
+++ b/quickstarts/hello-app/manifests/helloweb-computeclass-deployment.yaml
@@ -41,5 +41,5 @@ spec:
         resources:
           requests:
             cpu: "250m"
-            memory: "4Gi"
+            memory: "1Gi"
 # [END gke_helloweb_computeclass_deployment]


### PR DESCRIPTION
## Description

Reduce the memory request to `1Gi` so that the resulting machine type is a smaller size. 

## Tasks

<!-- Once the PR has been created, check boxes as appropriate. -->

* [x] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [x] The samples added / modified have been fully tested.
* [x] Workflow files have been added / modified, if applicable.
* [x] Region tags have been properly added, if new samples.
* [x] Editable variables have been used, where applicable.
* [x] All dependencies are set to up-to-date versions, as applicable.
* [x] Merge this pull-request for me once it is approved.
