### PR TITLE
Update helloweb-service-static-ip.yaml

### DIFF
--- a/quickstarts/hello-app/manifests/helloweb-service-static-ip.yaml
+++ b/quickstarts/hello-app/manifests/helloweb-service-static-ip.yaml
@@ -21,6 +21,8 @@ metadata:
   name: helloweb
   labels:
     app: hello
+  annotations:
+    networking.gke.io/load-balancer-ip-addresses: "helloweb-ip"
 spec:
   selector:
     app: hello
@@ -29,7 +31,6 @@ spec:
   - port: 80
     targetPort: 8080
   type: LoadBalancer
-  loadBalancerIP: "YOUR.IP.ADDRESS.HERE"
 # [END container_helloapp_service]
 # [END gke_manifests_helloweb_service_static_ip_service_helloweb]
 ---


### PR DESCRIPTION
## Description

The use of `.spec.loadBalancerIP` for a Service has been deprecated since Kubernetes v1.24. Replacing it with the `networking.gke.io/load-balancer-ip-addresses` annotation. The static IP name "helloweb-ip" is used in the doc that uses this yaml file: https://cloud.google.com/kubernetes-engine/docs/tutorials/configuring-domain-name-static-ip#use_a_service
This PR....

## Tasks

<!-- Once the PR has been created, check boxes as appropriate. -->

* [ ] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [ ] The samples added / modified have been fully tested.
* [ ] Workflow files have been added / modified, if applicable.
* [ ] Region tags have been properly added, if new samples.
* [ ] Editable variables have been used, where applicable.
* [ ] All dependencies are set to up-to-date versions, as applicable.
* [ ] Merge this pull-request for me once it is approved.
