### PR TITLE
Describe how to read a Pub/Sub topic from another project

### DIFF
--- a/cost-optimization/gke-keda/cloud-pubsub/deployment/keda-pubsub-with-workload-identity.yaml
+++ b/cost-optimization/gke-keda/cloud-pubsub/deployment/keda-pubsub-with-workload-identity.yaml
@@ -42,7 +42,7 @@ spec:
       serviceAccountName: keda-pubsub-sa
       containers:
       # Note: Set the GOOGLE_CLOUD_PROJECT environment variable if the Pub/Sub topic
-      # is not in the same GCP project as this Kubernetes cluster.
+      # is not in the same Google Cloud project as this Kubernetes cluster.
       - name: subscriber
         image: us-docker.pkg.dev/google-samples/containers/gke/keda-pubsub-sample:v1
 # [END gke_deployment_keda_pubsub_with_workflow_identity_deployment_pubsub]


### PR DESCRIPTION
## Description

The `GOOGLE_CLOUD_PROJECT` environment variable needs to be set to the project where the Pub/Sub topic resides.

This addresses https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/issues/1811