### PR TITLE
Fixed warnings brought up in Issue #1781

### DIFF
--- a/quickstarts/hello-app/Dockerfile
+++ b/quickstarts/hello-app/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # [START gke_quickstarts_hello_app_dockerfile]
-FROM golang:1.24.3 as builder
+FROM golang:1.24.3 AS builder
 WORKDIR /app
 RUN go mod init hello-app
 COPY *.go ./
@@ -22,7 +22,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o /hello-app
 FROM gcr.io/distroless/base-debian11
 WORKDIR /
 COPY --from=builder /hello-app /hello-app
-ENV PORT 8080
+ENV PORT=8080
 USER nonroot:nonroot
 CMD ["/hello-app"]
 # [END gke_quickstarts_hello_app_dockerfile]


### PR DESCRIPTION
## Description

This PR resolves the 2 warnings that were brought up in issue #1781 so that users trying the quickstart demo don't run into warnings.

## Tasks

* [x] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [x] The samples added / modified have been fully tested.
* [x] Workflow files have been added / modified, if applicable.
* [x] Region tags have been properly added, if new samples.
* [x] Editable variables have been used, where applicable.
* [x] All dependencies are set to up-to-date versions, as applicable.
* [x] Merge this pull-request for me once it is approved.
