### PR TITLE
Change filestore workload to delayed binding

### DIFF
--- a/databases/stateful-workload-filestore/filestore-storageclass.yaml
+++ b/databases/stateful-workload-filestore/filestore-storageclass.yaml
@@ -18,7 +18,7 @@ kind: StorageClass
 metadata:
   name: filestore-sc
 provisioner: filestore.csi.storage.gke.io
-volumeBindingMode: Immediate
+volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
 parameters:
   tier: standard


### PR DESCRIPTION

## Description

Change the filestore storage class to use delayed binding in order to work smoothly on autopilot clusters with no nodes.

Fixes: #1830

## Tasks

<!-- Once the PR has been created, check boxes as appropriate. -->

* [ X] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [ X] The samples added / modified have been fully tested.
* [ X] Workflow files have been added / modified, if applicable.
* [ X] Region tags have been properly added, if new samples.
* [ X] Editable variables have been used, where applicable.
* [ X] All dependencies are set to up-to-date versions, as applicable.
* [ X] Merge this pull-request for me once it is approved.
