### PR TITLE
Update Dockerfile to use static-debian12 base image

### DIFF
--- a/quickstarts/hello-app/Dockerfile
+++ b/quickstarts/hello-app/Dockerfile
@@ -19,7 +19,7 @@ RUN go mod init hello-app
 COPY *.go ./
 RUN CGO_ENABLED=0 GOOS=linux go build -o /hello-app
 
-FROM gcr.io/distroless/base-debian11
+FROM gcr.io/distroless/static-debian12@sha256:15bfbd671b2f71aa96538aa68638391d120c633e26c270f8bd6cac446304830c
 WORKDIR /
 COPY --from=builder /hello-app /hello-app
 ENV PORT=8080

--- a/quickstarts/hello-app/Dockerfile
+++ b/quickstarts/hello-app/Dockerfile
@@ -19,7 +19,7 @@ RUN go mod init hello-app
 COPY *.go ./
 RUN CGO_ENABLED=0 GOOS=linux go build -o /hello-app
 
-FROM gcr.io/distroless/static-debian12@sha256:15bfbd671b2f71aa96538aa68638391d120c633e26c270f8bd6cac446304830c
+FROM gcr.io/distroless/static-debian12
 WORKDIR /
 COPY --from=builder /hello-app /hello-app
 ENV PORT=8080


### PR DESCRIPTION
* See internal Buganizer: [b/503111624](http://b/503111624)
* This pull-request aims to shrink the base image used for the `gcr.io/google-samples/hello-app:1.0` image and the `gcr.io/google-samples/hello-app:2.0` image.
* Merging this pull-request will trigger a Google Cloud Build trigger that rebuilds the `containers/gke/hello-app` image. Once rebuilt, I can delete the old images (manually). See [related cloudbuild.yaml](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/1355d98e9eeef6fe8c6f230e2f4b24b20ef5914a/quickstarts/hello-app/cloudbuild.yaml).
* CI (specifically, `quickstarts-hello-app-ci`) is passing! 👍 