### PR TITLE
Add MaxText multislice Ray Train samples with region tags

### DIFF
--- a/ai-ml/gke-ray/raytrain/maxtext/maxtext_elastic_trainer.py
+++ b/ai-ml/gke-ray/raytrain/maxtext/maxtext_elastic_trainer.py
@@ -1,0 +1,69 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_ai_ml_gke_ray_ray_train_maxtext_maxtext_elastic_trainer]
+import os
+from absl import app
+import logging
+from typing import Sequence
+import ray
+from ray.train.v2.api.config import ScalingConfig, RunConfig, FailureConfig
+from ray.train.v2.jax import JaxTrainer
+
+def train_loop_per_worker(config):
+    import maxtext
+    from maxtext.trainers.pre_train.train import main as maxtext_main
+
+    argv = config["argv"]
+    maxtext_main(argv)
+
+def main(argv: Sequence[str]):
+    # Convert the config file path to an absolute path
+    argv = list(argv)
+    if len(argv) > 1:
+        argv[1] = os.path.abspath(argv[1])
+
+    trainer = JaxTrainer(
+        train_loop_per_worker=train_loop_per_worker,
+        train_loop_config={"argv": argv},
+        scaling_config=ScalingConfig(
+            use_tpu=True,
+            # This tells Ray to scale the number of workers between 4 and 8 (i.e. 1 to 2 TPU slices).
+            num_workers=(4,8),
+            topology="4x4",
+            accelerator_type="TPU-V6E",
+            resources_per_worker={"TPU": 4},
+            placement_strategy="SPREAD",
+        ),
+        run_config=RunConfig(
+            name="maxtext_jaxtrainer",
+            # Define a FailureConfig to enable fault tolerance by automatically restarting failed workers.
+            failure_config=FailureConfig(max_failures=3),
+            worker_runtime_env={
+                "uv": {
+                    # maxtext requires some additional deps
+                    "packages": ["maxtext[tpu]==0.2.1"],
+                    "uv_pip_install_options": ["--resolution=lowest"]
+                },
+            },
+        ),
+    )
+    result = trainer.fit()
+    logging.info("Training complete!")
+    ray.shutdown()
+
+if __name__ == "__main__":
+    app.run(main)
+
+# [END gke_ai_ml_gke_ray_ray_train_maxtext_maxtext_elastic_trainer]

--- a/ai-ml/gke-ray/raytrain/maxtext/maxtext_multi_slice_trainer.py
+++ b/ai-ml/gke-ray/raytrain/maxtext/maxtext_multi_slice_trainer.py
@@ -1,0 +1,66 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_ai_ml_gke_ray_ray_train_maxtext_maxtext_multi_slice_trainer]
+import os
+from absl import app
+import logging
+from typing import Sequence
+import ray
+from ray.train.v2.api.config import ScalingConfig, RunConfig
+from ray.train.v2.jax import JaxTrainer
+
+def train_loop_per_worker(config):
+    import maxtext
+    from maxtext.trainers.pre_train.train import main as maxtext_main
+
+    argv = config["argv"]
+    maxtext_main(argv)
+
+def main(argv: Sequence[str]):
+    # Convert the config file path to an absolute path
+    argv = list(argv)
+    if len(argv) > 1:
+        argv[1] = os.path.abspath(argv[1])
+
+    trainer = JaxTrainer(
+        train_loop_per_worker=train_loop_per_worker,
+        train_loop_config={"argv": argv},
+        scaling_config=ScalingConfig(
+            use_tpu=True,
+            num_workers=8,
+            topology="4x4",
+            accelerator_type="TPU-V6E",
+            resources_per_worker={"TPU": 4},
+            placement_strategy="SPREAD",
+        ),
+        run_config=RunConfig(
+            name="maxtext_jaxtrainer",
+            worker_runtime_env={
+                "uv": {
+                    # maxtext requires some additional deps
+                    "packages": ["maxtext[tpu]==0.2.1"],
+                    "uv_pip_install_options": ["--resolution=lowest"]
+                },
+            },
+        ),
+    )
+    result = trainer.fit()
+    logging.info("Training complete!")
+    ray.shutdown()
+
+if __name__ == "__main__":
+    app.run(main)
+
+# [END gke_ai_ml_gke_ray_ray_train_maxtext_maxtext_multi_slice_trainer]

--- a/ai-ml/gke-ray/raytrain/maxtext/ray-cluster.tpu-multi-slice.yaml
+++ b/ai-ml/gke-ray/raytrain/maxtext/ray-cluster.tpu-multi-slice.yaml
@@ -1,0 +1,145 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START gke_ai_ml_gke_ray_ray_train_maxtext_ray_cluster_tpu_multi_slice]
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: two-netdev
+spec:
+  spec:
+    devices:
+      requests:
+      - name: req-netdev
+        exactly:
+          deviceClassName: netdev.google.com
+          allocationMode: ExactCount
+          count: 2
+---
+apiVersion: ray.io/v1
+kind: RayCluster
+metadata:
+  name: maxtext-tpu-cluster
+spec:
+  headGroupSpec:
+    rayStartParams: {}
+    template:
+      metadata:
+        annotations:
+          gke-gcsfuse/volumes: "true"
+          gke-gcsfuse/cpu-limit: "0"
+          gke-gcsfuse/memory-limit: "0"
+          gke-gcsfuse/ephemeral-storage-limit: "0"
+      spec:
+        serviceAccountName: ${KSA_NAME}
+        containers:
+          - name: ray-head
+            image: rayproject/ray:nightly-py312-tpu
+            imagePullPolicy: Always
+            ports:
+            - containerPort: 6379
+              name: gcs-server
+            - containerPort: 8265
+              name: dashboard
+            - containerPort: 10001
+              name: client
+            resources:
+              limits:
+                memory: "16Gi"
+              requests:
+                cpu: "8"
+                memory: "16Gi"
+            volumeMounts:
+            - name: gcs-fuse-csi-ephemeral
+              mountPath: /data
+            - name: dshm
+              mountPath: /dev/shm
+        volumes:
+        - name: dshm
+          emptyDir:
+            medium: Memory
+        - name: gcs-fuse-csi-ephemeral
+          csi:
+            driver: gcsfuse.csi.storage.gke.io
+            volumeAttributes:
+              bucketName: ${GS_BUCKET}
+              mountOptions: "implicit-dirs,uid=1000,gid=1000,dir-mode=775,file-mode=664,file-cache:max-size-mb:-1"
+        nodeSelector:
+          iam.gke.io/gke-metadata-server-enabled: "true"
+  workerGroupSpecs:
+    - replicas: 2
+      numOfHosts: 4
+      groupName: tpu-group
+      rayStartParams: 
+        metrics-export-port: "8082"
+      template:
+        metadata:
+          annotations:
+            gke-gcsfuse/volumes: "true"
+            gke-gcsfuse/cpu-limit: "0"
+            gke-gcsfuse/memory-limit: "0"
+            gke-gcsfuse/ephemeral-storage-limit: "0"
+        spec:
+          serviceAccountName: ${KSA_NAME}
+          resourceClaims:
+          - name: netdev
+            resourceClaimTemplateName: two-netdev
+          containers:
+            - name: ray-worker
+              image: rayproject/ray:nightly-py312-tpu
+              imagePullPolicy: Always
+              resources:
+                claims:
+                - name: netdev
+                limits:
+                  memory: 200G
+                  google.com/tpu: "4"
+                requests:
+                  cpu: "8"
+                  memory: 200G
+                  google.com/tpu: "4"
+              env:
+                - name: MEGASCALE_NUM_SLICES
+                  value: "2"
+                - name: MEGASCALE_PORT
+                  value: "9915"
+                - name: JAX_PLATFORMS
+                  value: tpu,cpu
+                - name: ENABLE_PJRT_COMPATIBILITY
+                  value: "true"
+                - name: LIBTPU_INIT_ARGS
+                  value: "--xla_tpu_scoped_vmem_limit_kib=122880 --xla_tpu_use_minor_sharding_for_major_trivial_input=true --xla_tpu_relayout_group_size_threshold_for_reduce_scatter=1 --xla_tpu_assign_all_reduce_scatter_layout --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true --megascale_grpc_interface_prefixes=eth1,eth2,lo"
+              securityContext:
+                privileged: true
+              volumeMounts:
+              - name: gcs-fuse-csi-ephemeral
+                mountPath: /data
+              - name: dshm
+                mountPath: /dev/shm
+          volumes:
+          - name: dshm
+            emptyDir:
+              medium: Memory
+          - name: gcs-fuse-csi-ephemeral
+            csi:
+              driver: gcsfuse.csi.storage.gke.io
+              volumeAttributes:
+                bucketName: ${GS_BUCKET}
+                mountOptions: "implicit-dirs,uid=1000,gid=1000,dir-mode=775,file-mode=664,file-cache:max-size-mb:-1"
+          nodeSelector:
+            iam.gke.io/gke-metadata-server-enabled: "true"
+            cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
+            cloud.google.com/gke-tpu-topology: 4x4
+
+# [END gke_ai_ml_gke_ray_ray_train_maxtext_ray_cluster_tpu_multi_slice]


### PR DESCRIPTION
## Description

This PR adds multi-slice samples for Ray Train with Maxtext on GKE on Trillium TPUs. These samples are part of an upcoming guide and have been tested e2e.

## Tasks

<!-- Once the PR has been created, check boxes as appropriate. -->

* [x] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [x] The samples added / modified have been fully tested.
* [x] Workflow files have been added / modified, if applicable.
* [x] Region tags have been properly added, if new samples.
* [x] Editable variables have been used, where applicable.
* [x] All dependencies are set to up-to-date versions, as applicable.
* [x] Merge this pull-request for me once it is approved.
