### PR TITLE
Update Go base image version in Dockerfile

### DIFF
--- a/quickstarts/hello-app/Dockerfile
+++ b/quickstarts/hello-app/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # [START gke_quickstarts_hello_app_dockerfile]
-FROM golang:1.24.3 AS builder
+FROM golang:1.26.2 AS builder
 WORKDIR /app
 RUN go mod init hello-app
 COPY *.go ./


### PR DESCRIPTION
See my comment from Apr 23 at [b/503111624](http://b/503111624).
This is a follow-up to https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/pull/2031, which only cleared out some of the CVEs we wanted to clear out.