### PR TITLE
Fix kueue.x-k8s.io/queue-name metadata field 

### DIFF
--- a/batch/kueue-intro/job-team-a.yaml
+++ b/batch/kueue-intro/job-team-a.yaml
@@ -18,7 +18,7 @@ kind: Job
 metadata:
   namespace: team-a # Job under team-a namespace
   generateName: sample-job-team-a-
-  annotations:
+  labels:
     kueue.x-k8s.io/queue-name: lq-team-a # Point to the LocalQueue
 spec:
   ttlSecondsAfterFinished: 60 # Job will be deleted after 60 seconds

--- a/batch/kueue-intro/job-team-b.yaml
+++ b/batch/kueue-intro/job-team-b.yaml
@@ -18,7 +18,7 @@ kind: Job
 metadata:
   namespace: team-b # Job under team-b namespace
   generateName: sample-job-team-b-
-  annotations:
+  labels:
     kueue.x-k8s.io/queue-name: lq-team-b # Point to the LocalQueue
 spec:
   ttlSecondsAfterFinished: 60 # Job will be deleted after 60 seconds


### PR DESCRIPTION
## Description

This PR updates YAML samples that include the kueue.x-k8s.io/queue-name field under metadata.annotations. According to the official OSS Kueue documentation ([Labels and Annotations](https://kueue.sigs.k8s.io/docs/reference/labels-and-annotations/#kueuex-k8sioqueue-name)), this field must be a metadata.label.

Using it as an annotation means Kueue will not recognize the Job's intended queue, causing the Jobs to not be admitted to the LocalQueues as expected.

## Tasks

<!-- Once the PR has been created, check boxes as appropriate. -->

* [x] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [ ] The samples added / modified have been fully tested.
* [ ] Workflow files have been added / modified, if applicable.
* [ ] Region tags have been properly added, if new samples.
* [ ] Editable variables have been used, where applicable.
* [ ] All dependencies are set to up-to-date versions, as applicable.
* [ ] Merge this pull-request for me once it is approved.
