### PR TITLE
Fix quickstart Dockerfile warnings

### DIFF
--- a/quickstarts/hello-app-cdn/Dockerfile
+++ b/quickstarts/hello-app-cdn/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.24.3 as builder
+FROM golang:1.24.3 AS builder
 WORKDIR /app
 RUN go mod init hello-app-cdn
 COPY *.go ./
@@ -21,6 +21,6 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o /hello-app-cdn
 FROM gcr.io/distroless/base-debian11
 WORKDIR /
 COPY --from=builder /hello-app-cdn /hello-app-cdn
-ENV PORT 8080
+ENV PORT=8080
 USER nonroot:nonroot
 CMD ["/hello-app-cdn"]

--- a/quickstarts/hello-app-redis/Dockerfile
+++ b/quickstarts/hello-app-redis/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.24.3 as builder
+FROM golang:1.24.3 AS builder
 WORKDIR /app
 RUN go mod init hello-app-redis
 COPY * ./
@@ -21,6 +21,6 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o /hello-app-redis
 FROM gcr.io/distroless/base-debian11
 WORKDIR /
 COPY --from=builder /hello-app-redis /hello-app-redis
-ENV PORT 8080
+ENV PORT=8080
 USER nonroot:nonroot
 CMD ["/hello-app-redis"]

--- a/quickstarts/hello-app-tls/Dockerfile
+++ b/quickstarts/hello-app-tls/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.24.3 as builder
+FROM golang:1.24.3 AS builder
 WORKDIR /app
 RUN go mod init hello-app-tls
 COPY *.go ./

--- a/quickstarts/languages/go/Dockerfile
+++ b/quickstarts/languages/go/Dockerfile
@@ -16,7 +16,7 @@
 # Use the offical Go image to create a build artifact.
 # This is based on Debian and sets the GOPATH to /go.
 # https://hub.docker.com/_/golang
-FROM golang:1.24.3 as builder
+FROM golang:1.24.3 AS builder
 WORKDIR /app
 
 # Initialize a new Go module.

--- a/quickstarts/languages/java/Dockerfile
+++ b/quickstarts/languages/java/Dockerfile
@@ -15,7 +15,7 @@
 # [START gke_quickstarts_languages_java_dockerfile]
 # Use the official maven/Java 8 image to create a build artifact.
 # https://hub.docker.com/_/maven
-FROM maven:3.6-jdk-8-alpine as builder
+FROM maven:3.6-jdk-8-alpine AS builder
 
 # Copy local code to the container image.
 WORKDIR /app

--- a/quickstarts/languages/python/Dockerfile
+++ b/quickstarts/languages/python/Dockerfile
@@ -18,7 +18,7 @@
 FROM python:3.13-slim
 
 # Copy local code to the container image.
-ENV APP_HOME /app
+ENV APP_HOME=/app
 WORKDIR $APP_HOME
 COPY . ./
 


### PR DESCRIPTION
## Description

This PR updates the remaining quickstart Dockerfiles that still use Dockerfile forms covered by the warnings in #1781. The main `quickstarts/hello-app` Dockerfile was already fixed in #1829; this follows the same format for related quickstart samples.

Changes:

* Use `AS` for multi-stage builder aliases.
* Use `ENV key=value` for quickstart environment variables.

Validation:

* `git diff --check`
* Checked the modified quickstart Dockerfiles no longer match `FROM ... as` or legacy `ENV key value` forms.
* Tried a local `docker build` for `quickstarts/hello-app-cdn`, but this machine is missing the Docker buildx component and the legacy builder stalled while pulling `golang:1.24.3`; leaving this as draft until CI/maintainers can confirm.

Related to #1781.

## Tasks

* [x] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [ ] The samples added / modified have been fully tested.
* [ ] Workflow files have been added / modified, if applicable.
* [x] Region tags have been properly added, if new samples.
* [x] Editable variables have been used, where applicable.
* [x] All dependencies are set to up-to-date versions, as applicable.
* [ ] Merge this pull-request for me once it is approved.