### PR TITLE
Fix Ruby quickstart container startup

### DIFF
--- a/quickstarts/languages/ruby/Dockerfile
+++ b/quickstarts/languages/ruby/Dockerfile
@@ -1,14 +1,18 @@
 # Use the official lightweight Ruby image.
 # https://hub.docker.com/_/ruby
 FROM ruby:3.3-slim
+ENV RACK_ENV=production
 
 # Install production dependencies.
 WORKDIR /usr/src/app
-COPY Gemfile ./
-RUN bundle install
+COPY Gemfile Gemfile.lock ./
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential \
+    && bundle install \
+    && apt-get purge -y --auto-remove build-essential \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy local code to the container image.
 COPY . ./
 
 # Run the web service on container startup.
-CMD ["ruby", "./app.rb"]
+CMD ["bundle", "exec", "ruby", "./app.rb"]

--- a/quickstarts/languages/ruby/Gemfile
+++ b/quickstarts/languages/ruby/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 gem 'sinatra'
 gem 'rack', '>= 2.0.6'
+gem 'rackup'
+gem 'puma'

--- a/quickstarts/languages/ruby/Gemfile.lock
+++ b/quickstarts/languages/ruby/Gemfile.lock
@@ -1,0 +1,41 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    base64 (0.3.0)
+    logger (1.7.0)
+    mustermann (3.1.1)
+    nio4r (2.7.5)
+    puma (8.0.2)
+      nio4r (~> 2.0)
+    rack (3.2.6)
+    rack-protection (4.2.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.1.2)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
+    rackup (2.3.1)
+      rack (>= 3)
+    sinatra (4.2.1)
+      logger (>= 1.6.0)
+      mustermann (~> 3.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.2.1)
+      rack-session (>= 2.0.0, < 3)
+      tilt (~> 2.0)
+    tilt (2.7.0)
+
+PLATFORMS
+  aarch64-linux
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  puma
+  rack (>= 2.0.6)
+  rackup
+  sinatra
+
+BUNDLED WITH
+   2.5.22


### PR DESCRIPTION
## Description

Fixes #901.

The Ruby quickstart was still missing the server gems required by current Sinatra. Building the image with the existing Gemfile and starting it in the `ruby:3.3-slim` container fails because Sinatra 4 cannot find a Rack handler.

This PR adds the missing `rackup` and `puma` runtime dependencies, commits a lockfile for reproducible container builds, and runs the app through `bundle exec`. The Dockerfile installs build tools only for `bundle install`, then removes them from the final image layer.

Validation:

* `docker build -t kes-ruby-quickstart-test quickstarts/languages/ruby`
* `docker run -d --name kes-ruby-quickstart-test-run -p 18080:8080 -e TARGET=GKE kes-ruby-quickstart-test`
* `curl -fsS http://localhost:18080/` returned `Hello GKE!`
* Container logs show Sinatra 4.2.1 running with Puma 8.0.2 in production mode.
* `git diff --check`

## Tasks

* [x] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [x] The samples added / modified have been fully tested.
* [ ] Workflow files have been added / modified, if applicable.
* [x] Region tags have been properly added, if new samples.
* [x] Editable variables have been used, where applicable.
* [x] All dependencies are set to up-to-date versions, as applicable.
* [ ] Merge this pull-request for me once it is approved.