### PR TITLE
Add safe-to-evict annotations to DRA installers

### DIFF
--- a/autoscaling/custom-compute-classes/dra/README.md
+++ b/autoscaling/custom-compute-classes/dra/README.md
@@ -91,6 +91,8 @@ For the GPUs we will use in this example, the following command is sufficient:
 
 ```console
 kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/ubuntu/daemonset-preloaded.yaml
+kubectl patch daemonset nvidia-driver-installer -n kube-system -p \
+  '{"spec":{"template":{"metadata":{"annotations":{"cluster-autoscaler.kubernetes.io/safe-to-evict":"true"}}}}}'
 ```
 
 The container toolkit is installed via a DaemonSet:

--- a/autoscaling/custom-compute-classes/dra/nvidia-container-toolkit-installer.yaml
+++ b/autoscaling/custom-compute-classes/dra/nvidia-container-toolkit-installer.yaml
@@ -25,6 +25,8 @@ spec:
       app: nvidia-container-toolkit-installer
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: nvidia-container-toolkit-installer
     spec:


### PR DESCRIPTION
Fixes #1740.

The DRA guide applies the NVIDIA driver installer from the container-engine-accelerators repo. That DaemonSet runs in kube-system and can block scale-down unless the pod template is marked safe to evict.

This updates the guide to patch the driver installer after applying it, and marks the local NVIDIA container toolkit installer DaemonSet the same way.

Validation:
- ruby -e YAML.load_file(...) check for nvidia-container-toolkit-installer.yaml
- jq validation for the README patch payload
- git diff --check

I could not run kubectl client-side dry-run locally because kubectl is not installed in this environment.