### PR TITLE
Fix T5 model serving doc links

### DIFF
--- a/ai-ml/t5-model-serving/README.md
+++ b/ai-ml/t5-model-serving/README.md
@@ -1,5 +1,7 @@
 # Serving T5 Large Language Model with TorchServe
 
-[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/kubernetes-engine-samples&cloudshell_tutorial=README.md&cloudshell_workspace=ai-ml/t5-model-serve)
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/GoogleCloudPlatform/kubernetes-engine-samples&cloudshell_tutorial=README.md&cloudshell_workspace=ai-ml/t5-model-serving)
 
 This tutorial shows how to run a serve of [T5 Large Language Model](https://huggingface.co/t5-small) with [TorchServe](https://pytorch.org/serve/) on GKE.
+
+For the full Google Cloud tutorial, see [Serve scalable LLMs on GKE with TorchServe](https://cloud.google.com/kubernetes-engine/docs/tutorials/scalable-ml-models-torchserve).


### PR DESCRIPTION
Updates #646.

## What
- Fix the Cloud Shell badge workspace for `ai-ml/t5-model-serving` so it points at the existing sample directory.
- Add the Google Cloud tutorial link for the T5 TorchServe sample.

## Testing
- `git diff --check`
- `test -d ai-ml/t5-model-serving && test ! -d ai-ml/t5-model-serve`
- `curl -sSI -L https://cloud.google.com/kubernetes-engine/docs/tutorials/scalable-ml-models-torchserve | rg "^HTTP/"`