### PR TITLE
Add gVisor toleration to anthropic-agent-sandbox SandboxTemplate for GKE 1.35.5+ secure-sandbox-policy

### DIFF
--- a/ai-ml/anthropic-agent-sandbox/deploy/base/sandbox-template.yaml
+++ b/ai-ml/anthropic-agent-sandbox/deploy/base/sandbox-template.yaml
@@ -32,6 +32,11 @@ spec:
       runtimeClassName: gvisor
       nodeSelector:
         sandbox.gke.io/runtime: gvisor
+      tolerations:
+        - key: sandbox.gke.io/runtime
+          operator: Equal
+          value: gvisor
+          effect: NoSchedule
       automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
## Description

GKE 1.35.5 ships a ValidatingAdmissionPolicy (`secure-sandbox-policy`) that denies any Sandbox whose podTemplate does not tolerate `sandbox.gke.io/runtime=gvisor:NoSchedule`. Without this toleration the SandboxWarmPool silently stays at 0 ready with no events on the pool, so the example stops working on clusters at or above 1.35.5. This PR adds the toleration to the `SandboxTemplate`. Follow-up to #2090.

## Tasks

* [x] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [x] The samples added / modified have been fully tested.
* [ ] Workflow files have been added / modified, if applicable.
* [x] Region tags have been properly added, if new samples.
* [x] Editable variables have been used, where applicable.
* [x] All dependencies are set to up-to-date versions, as applicable.
* [ ] Merge this pull-request for me once it is approved.