### PR TITLE
Fix missing 'packaging' dependency

### DIFF
--- a/cost-optimization/gke-keda/cloud-pubsub/requirements.txt
+++ b/cost-optimization/gke-keda/cloud-pubsub/requirements.txt
@@ -1,2 +1,3 @@
 google-cloud-pubsub~=2.23.0
 google-auth~=2.34.0
+google-api-core~=2.28.1


### PR DESCRIPTION
## Description

This PR fixes a dependency issue where the 'packaging' dependency is missing.

The symptom is a container log containing the `ModuleNotFoundError: No module named 'packaging'` error.

This problem is discussed in https://github.com/googleapis/python-api-core/issues/848 and is resolved in google-api-core 2.28.1+.

## Tasks

* [X] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [X] The samples added / modified have been fully tested.
* [X] Workflow files have been added / modified, if applicable.
* [X] Region tags have been properly added, if new samples.
* [X] Editable variables have been used, where applicable.
* [X] All dependencies are set to up-to-date versions, as applicable.
* [X] Merge this pull-request for me once it is approved.
