### PR TITLE
Add YAML manifests for GKE TPU dynamic slicing user guides

### DIFF
--- a/ai-ml/gke-tpu-dynamic-slicing/big-super-slice.yaml
+++ b/ai-ml/gke-tpu-dynamic-slicing/big-super-slice.yaml
@@ -1,0 +1,55 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: big-super-slice
+  labels:
+    kueue.x-k8s.io/queue-name: lq
+spec:
+  replicatedJobs:
+    - name: job-jax
+      replicas: 1
+      template:
+        spec:
+          parallelism: 192  # pods per slice calculation: 4*12*16 / 4 = 192
+          completions: 192
+          backoffLimit: 10
+          template:
+            metadata:
+              annotations:
+                cloud.google.com/gke-tpu-slice-topology: 4x12x16
+            spec:
+              tolerations:
+                - key: "google.com/tpu"
+                  operator: "Equal"
+                  value: "present"
+                  effect: "NoSchedule"
+              nodeSelector:
+                cloud.google.com/gke-tpu-accelerator: tpu7x
+              containers:
+                - name: jax
+                  image: python:latest
+                  command:
+                    - bash
+                    - -c
+                    - |
+                      printenv
+                      pip install "jax[tpu]" -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+                      python -c 'import jax; print("Global device count:", jax.device_count(), "Local device count:", jax.local_device_count())'
+                  resources:
+                    limits:
+                      google.com/tpu: 4
+              restartPolicy: Never

--- a/ai-ml/gke-tpu-dynamic-slicing/dynamic-slice-topology.yaml
+++ b/ai-ml/gke-tpu-dynamic-slicing/dynamic-slice-topology.yaml
@@ -1,0 +1,69 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: Topology
+metadata:
+  name: superslice-topology
+spec:
+  levels:
+  # Label to identify the physical block a sub-block belongs to.
+  # Only sub-blocks from the same block can form a slice.
+  - nodeLabel: cloud.google.com/gce-topology-block
+  # Label to identify individual TPU sub-blocks (4x4x4 topology).
+  - nodeLabel: cloud.google.com/gke-tpu-partition-4x4x4-id
+  # Standard Kubernetes label for individual nodes.
+  # Required to assign Pods to specific VMs.
+  - nodeLabel: kubernetes.io/hostname
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: superslice-rf
+spec:
+  nodeLabels:
+    cloud.google.com/gke-tpu-accelerator: tpu7x
+  topologyName: superslice-topology
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: AdmissionCheck
+metadata:
+  name: superslice-ac
+spec:
+  controllerName: accelerator.gke.io/slice
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  name: cq
+spec:
+  namespaceSelector: {}
+  admissionChecks:
+  - superslice-ac
+  resourceGroups:
+  - coveredResources:
+    - google.com/tpu
+    flavors:
+    - name: superslice-rf
+      resources:
+      - name: google.com/tpu
+        nominalQuota: "999999"  # modeling unlimited quota
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata:
+  name: lq
+  namespace: default
+spec:
+  clusterQueue: cq

--- a/ai-ml/gke-tpu-dynamic-slicing/slice-controller.yaml
+++ b/ai-ml/gke-tpu-dynamic-slicing/slice-controller.yaml
@@ -1,0 +1,455 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: slice-controller
+    control-plane: controller-manager
+  name: slice-controller-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: slice-controller
+    control-plane: controller-manager
+  name: slice-controller-controller-manager
+  namespace: slice-controller-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: slice-controller
+    control-plane: controller-manager
+  name: slice-controller-leader-election-role
+  namespace: slice-controller-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: slice-controller-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - accelerator.gke.io
+  resources:
+  - slices
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - accelerator.gke.io
+  resources:
+  - slices/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - jobset.x-k8s.io
+  resources:
+  - jobsets
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - leaderworkerset.x-k8s.io
+  resources:
+  - leaderworkersets
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - admissionchecks
+  - admissionchecks/status
+  - workloads/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - workloads
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: slice-controller-metrics-auth-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: slice-controller-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: slice-controller
+    control-plane: controller-manager
+  name: slice-controller-leader-election-rolebinding
+  namespace: slice-controller-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: slice-controller-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: slice-controller-controller-manager
+  namespace: slice-controller-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: slice-controller
+    control-plane: controller-manager
+  name: slice-controller-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: slice-controller-manager-role
+subjects:
+- kind: ServiceAccount
+  name: slice-controller-controller-manager
+  namespace: slice-controller-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: slice-controller-metrics-auth-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: slice-controller-metrics-auth-role
+subjects:
+- kind: ServiceAccount
+  name: slice-controller-controller-manager
+  namespace: slice-controller-system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: slice-controller-webhook-server-cert
+  namespace: slice-controller-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: slice-controller
+    control-plane: controller-manager
+  name: slice-controller-controller-manager-metrics-service
+  namespace: slice-controller-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app.kubernetes.io/name: slice-controller
+    control-plane: controller-manager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: slice-controller-webhook-service
+  namespace: slice-controller-system
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: slice-controller
+    control-plane: controller-manager
+  name: slice-controller-controller-manager
+  namespace: slice-controller-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: slice-controller
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        app.kubernetes.io/name: slice-controller
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --metrics-bind-address=:8443
+        - --leader-elect
+        - --health-probe-bind-address=:8081
+        - --zap-log-level=3
+        - --feature-gates=UseRetryMechanismForSliceCreation=true
+        - --activation-timeout=6m
+        command:
+        - /manager
+        image: tpuongke/kueue-slice-controller:latest
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 12000m
+            memory: 32Gi
+          requests:
+            cpu: 8000m
+            memory: 16Gi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      serviceAccountName: slice-controller-controller-manager
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: slice-controller-webhook-server-cert
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    control-plane: controller-manager
+  name: slice-controller-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: slice-controller-webhook-service
+      namespace: slice-controller-system
+      path: /mutate-batch-v1-job
+  failurePolicy: Fail
+  name: mjob.kb.io
+  rules:
+  - apiGroups:
+    - batch
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - jobs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: slice-controller-webhook-service
+      namespace: slice-controller-system
+      path: /mutate-jobset-x-k8s-io-v1alpha2-jobset
+  failurePolicy: Fail
+  name: mjobset.kb.io
+  rules:
+  - apiGroups:
+    - jobset.x-k8s.io
+    apiVersions:
+    - v1alpha2
+    operations:
+    - CREATE
+    resources:
+    - jobsets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: slice-controller-webhook-service
+      namespace: slice-controller-system
+      path: /mutate-leaderworkerset-x-k8s-io-v1-leaderworkerset
+  failurePolicy: Fail
+  name: mleaderworkerset.kb.io
+  rules:
+  - apiGroups:
+    - leaderworkerset.x-k8s.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - leaderworkersets
+  sideEffects: None

--- a/ai-ml/gke-tpu-dynamic-slicing/tpu-job-jax-v7x-64.yaml
+++ b/ai-ml/gke-tpu-dynamic-slicing/tpu-job-jax-v7x-64.yaml
@@ -1,0 +1,64 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: headless-svc
+spec:
+  clusterIP: None
+  selector:
+    job-name: tpu-job-jax-v7x-64
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: tpu-job-jax-v7x-64
+spec:
+  backoffLimit: 0
+  completions: 16
+  parallelism: 16
+  completionMode: Indexed
+  template:
+    metadata:
+      annotations:
+        cloud.google.com/gke-tpu-slice-topology: 4x4x4
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-tpu-topology: 4x4x4
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+        cloud.google.com/gke-tpu-slice: test-slice
+      subdomain: headless-svc
+      restartPolicy: Never
+      containers:
+      - name: tpu-job-jax
+        env:
+        - name: TPU_ACCELERATOR_TYPE
+          value: tpu7x-128
+        image: python:3.12
+        securityContext:
+          privileged: false
+        command:
+        - bash
+        - -c
+        - |
+          set -ex
+          pip install -U --pre jax jaxlib libtpu requests -i https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/ -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+          pip list
+          python -c 'import jax; print("Total TPU devices (cores):", jax.device_count())'
+        resources:
+          requests:
+            google.com/tpu: 4
+          limits:
+            google.com/tpu: 4

--- a/ai-ml/gke-tpu-dynamic-slicing/tpu-multislice-jax.yaml
+++ b/ai-ml/gke-tpu-dynamic-slicing/tpu-multislice-jax.yaml
@@ -1,0 +1,66 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: tpu-multislice-jax
+  annotations:
+    alpha.jobset.sigs.k8s.io/exclusive-topology: cloud.google.com/gke-tpu-slice
+spec:
+  failurePolicy:
+    maxRestarts: 3
+  replicatedJobs:
+  - name: slice-job
+    replicas: 2
+    template:
+      spec:
+        parallelism: 16
+        completions: 16
+        backoffLimit: 0
+        completionMode: Indexed
+        template:
+          metadata:
+            annotations:
+              # The shape of the slice
+              cloud.google.com/gke-tpu-slice-topology: 4x4x4
+          spec:
+            hostNetwork: true
+            dnsPolicy: ClusterFirstWithHostNet
+            nodeSelector:
+              cloud.google.com/gke-tpu-topology: 4x4x4
+              cloud.google.com/gke-tpu-accelerator: tpu7x
+              # IMPORTANT: Do NOT put 'cloud.google.com/gke-tpu-slice' here manually.
+              # The exclusive-topology annotation handles the slice assignment automatically.
+            containers:
+            - name: jax-worker
+              image: python:3.12
+              securityContext:
+                privileged: true
+              ports:
+              - containerPort: 8471
+              command:
+              - bash
+              - -c
+              - |
+                set -ex
+                pip install -U --pre jax jaxlib libtpu requests -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+                # Verify JobSet injected the specific slice ID for this worker
+                echo "JobSet Index: $JOB_COMPLETION_INDEX"
+                python -c 'import jax; print("Total TPU devices:", jax.device_count())'
+              resources:
+                requests:
+                  google.com/tpu: 4
+                limits:
+                  google.com/tpu: 4

--- a/ai-ml/gke-tpu-dynamic-slicing/two-super-slices.yaml
+++ b/ai-ml/gke-tpu-dynamic-slicing/two-super-slices.yaml
@@ -1,0 +1,56 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: two-super-slices
+  labels:
+    kueue.x-k8s.io/queue-name: lq
+spec:
+  replicatedJobs:
+    - name: job-jax
+      replicas: 2
+      template:
+        spec:
+          parallelism: 64  # Pods per slice calculation: (4*8*8) / 4 = 64
+          completions: 64
+          backoffLimit: 10
+          template:
+            metadata:
+              annotations:
+                cloud.google.com/gke-tpu-slice-topology: 4x8x8
+            spec:
+              tolerations:
+                - key: "google.com/tpu"
+                  operator: "Equal"
+                  value: "present"
+                  effect: "NoSchedule"
+              nodeSelector:
+                cloud.google.com/gke-tpu-accelerator: tpu7x
+                cloud.google.com/gke-tpu-partition-4x4x4-state: "HEALTHY"
+              containers:
+                - name: jax
+                  image: python:latest
+                  command:
+                    - bash
+                    - -c
+                    - |
+                      printenv
+                      pip install "jax[tpu]" -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+                      python -c 'import jax; print("Global device count:", jax.device_count(), "Local device count:", jax.local_device_count())'
+                  resources:
+                    limits:
+                      google.com/tpu: 4
+              restartPolicy: Never


### PR DESCRIPTION
## Description

This PR adds the standalone YAML manifests for GKE TPU dynamic slicing under `ai-ml/gke-tpu-dynamic-slicing/` to resolve devsite rendering and indentation issues in the documentation.
Manifests added:
- `big-super-slice.yaml`: JobSet manifest for single `4x12x16` super-slice workload.
- `two-super-slices.yaml`: JobSet manifest for multi-replica (`replicas: 2`) `4x8x8` super-slice workload.
- `dynamic-slice-topology.yaml`: Kueue dynamic slice topology, ResourceFlavor, AdmissionCheck, ClusterQueue, and LocalQueue configuration.
- `slice-controller.yaml`: Deployment manifest for Kueue slice controller.
- `tpu-job-jax-v7x-64.yaml`: JAX Job workload for a single `4x4x4` sub-block.
- `tpu-multislice-jax.yaml`: Multi-slice JAX JobSet workload (`4x4x4`).

## Tasks

<!-- Once the PR has been created, check boxes as appropriate. -->

* [x] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [x] The samples added / modified have been fully tested.
* [x] Workflow files have been added / modified, if applicable.
* [x] Region tags have been properly added, if new samples.
* [x] Editable variables have been used, where applicable.
* [x] All dependencies are set to up-to-date versions, as applicable.
* [x] Merge this pull-request for me once it is approved.
