### PR TITLE
Add README for GKE TPU Dynamic Slicing with link to the tutorial

### DIFF
--- a/ai-ml/gke-tpu-dynamic-slicing/README.md
+++ b/ai-ml/gke-tpu-dynamic-slicing/README.md
@@ -1,0 +1,5 @@
+# GKE TPU Dynamic Slicing
+
+These samples show how to configure and use GKE dynamic slicing for Cloud TPUs.
+
+Visit https://cloud.google.com/kubernetes-engine/docs/how-to/use-gke-dynamic-slicing to follow the tutorial.

--- a/ai-ml/gke-tpu-dynamic-slicing/README.md
+++ b/ai-ml/gke-tpu-dynamic-slicing/README.md
@@ -1,5 +1,5 @@
-# GKE TPU Dynamic Slicing
+# GKE Kueue TPU Dynamic Slicing
 
-These samples show how to configure and use GKE dynamic slicing for Cloud TPUs.
+These samples show how to configure and use GKE dynamic slicing with Kueue for Cloud TPUs.
 
 Visit https://cloud.google.com/kubernetes-engine/docs/how-to/use-gke-dynamic-slicing to follow the tutorial.


### PR DESCRIPTION
## Description
This PR adds the README for standalone YAML manifests for GKE TPU dynamic slicing under `ai-ml/gke-tpu-dynamic-slicing/`. 
Changes included:
- `README.md`: Added the standard sample landing page to link directly to the Cloud tutorial 
-
## Tasks
* [x] The [contributing guide](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/blob/main/.github/CONTRIBUTING.md) has been read and followed.
* [x] The samples added / modified have been fully tested.
* [x] Workflow files have been added / modified, if applicable.
* [x] Region tags have been properly added, if new samples.
* [x] Editable variables have been used, where applicable.
* [x] All dependencies are set to up-to-date versions, as applicable.
* [x] Merge this pull-request for me once it is approved.